### PR TITLE
Upgrade to latest chuckpad-social library

### DIFF
--- a/src/ios/mAAppDelegate.mm
+++ b/src/ios/mAAppDelegate.mm
@@ -35,7 +35,7 @@
 #import "mAAnalytics.h"
 #import "mAPreferences.h"
 
-
+#import "ChuckPadSocial.h"
 
 NSString * const kmAUserDefaultsSelectedScript = @"mAUserDefaultsSelectedScript";
 
@@ -113,6 +113,8 @@ static mAAppDelegate *g_appDelegate = nil;
     {
         [self finishLaunchWithOptions:launchOptions];
     }
+    
+    [ChuckPadSocial bootstrapForPatchType:MiniAudicle];
     
     return YES;
 }

--- a/src/ios/mASocialLoginViewController.m
+++ b/src/ios/mASocialLoginViewController.m
@@ -236,9 +236,22 @@
     UIAlertMessage2(@"Are you sure you want to logout?",
                     @"Cancel", ^{ },
                     @"Logout", ^{
-                        ChuckPadSocial *chuckPad = [ChuckPadSocial sharedInstance];
-                        [chuckPad logOut];
-                        [self _configureTabs];
+                        [self _showLoading:YES status:@"Logging out"];
+                        [[ChuckPadSocial sharedInstance] logOut:^(BOOL succeeded, NSError *error) {
+                            [self _showLoading:NO];
+                            
+                            // If we can't invalidate the auth token on the service, just wipe it locally. It's not that
+                            // big a deal to have a stale auth token on the service.
+                            if (!succeeded) {
+                                [[ChuckPadSocial sharedInstance] localLogOut];
+                            }
+                            
+                            UIAlertMessage(@"Successfully logged out", ^{
+                                [self _dismiss];
+                            });
+                            
+                            [self _configureTabs];
+                        }];
                     });
 }
 

--- a/src/ios/mASocialShareViewController.m
+++ b/src/ios/mASocialShareViewController.m
@@ -303,8 +303,10 @@ typedef enum ShareMode
         [self _showLoading:YES status:@"Uploading patch"];
         
         [chuckPad uploadPatch:name
-                  description:description parent:-1
-                     filename:filename fileData:fileData
+                  description:description
+                       parent:nil
+                    patchData:fileData
+                extraMetaData:nil
                      callback:^(BOOL succeeded, Patch *patch, NSError *error) {
                          if(succeeded)
                          {
@@ -332,8 +334,11 @@ typedef enum ShareMode
         [self _showLoading:YES status:@"Updating patch"];
         
         [chuckPad updatePatch:self.script.patch
-                       hidden:@NO name:name description:description
-                     filename:filename fileData:fileData
+                       hidden:@NO
+                         name:name
+                  description:description
+                    patchData:fileData
+                extraMetaData:nil
                      callback:^(BOOL succeeded, Patch *patch, NSError *error) {
                          if(succeeded)
                          {

--- a/src/miniAudicle.xcodeproj/project.pbxproj
+++ b/src/miniAudicle.xcodeproj/project.pbxproj
@@ -445,17 +445,9 @@
 		09F2D4681CEC7C7B006E488B /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09F2D4671CEC7C7B006E488B /* CoreLocation.framework */; };
 		09F330361D46D37B002792BA /* mASocialFileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F330351D46D37B002792BA /* mASocialFileViewController.m */; };
 		09F3303A1D46D4AC002792BA /* mASocialFileViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09F330391D46D4AC002792BA /* mASocialFileViewController.xib */; };
-		09F330551D46DCDB002792BA /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F3303E1D46DCDB002792BA /* AFHTTPSessionManager.m */; };
-		09F330561D46DCDB002792BA /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F330411D46DCDB002792BA /* AFNetworkReachabilityManager.m */; };
-		09F330571D46DCDB002792BA /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F330431D46DCDB002792BA /* AFSecurityPolicy.m */; };
-		09F330581D46DCDB002792BA /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F330451D46DCDB002792BA /* AFURLRequestSerialization.m */; };
-		09F330591D46DCDB002792BA /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F330471D46DCDB002792BA /* AFURLResponseSerialization.m */; };
-		09F3305A1D46DCDB002792BA /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F330491D46DCDB002792BA /* AFURLSessionManager.m */; };
 		09F3305B1D46DCDB002792BA /* ChuckPadSocial.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F3304B1D46DCDB002792BA /* ChuckPadSocial.m */; };
 		09F3305C1D46DCDB002792BA /* FXKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F3304E1D46DCDB002792BA /* FXKeychain.m */; };
-		09F3305D1D46DCDB002792BA /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 09F3304F1D46DCDB002792BA /* LICENSE */; };
 		09F3305E1D46DCDB002792BA /* Patch.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F330511D46DCDB002792BA /* Patch.m */; };
-		09F3305F1D46DCDB002792BA /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = 09F330521D46DCDB002792BA /* README.md */; };
 		09F330601D46DCDB002792BA /* User.m in Sources */ = {isa = PBXBuildFile; fileRef = 09F330541D46DCDB002792BA /* User.m */; };
 		09F330621D46DCE6002792BA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09F330611D46DCE6002792BA /* Security.framework */; };
 		09F376EB0BBC97D6005931F6 /* removelast.png in Resources */ = {isa = PBXBuildFile; fileRef = 09F376E60BBC97D6005931F6 /* removelast.png */; };
@@ -475,6 +467,12 @@
 		4D3D4C981A5E3A4400B6A06B /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D3D4C971A5E3A4400B6A06B /* SystemConfiguration.framework */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		AD7244541DFF6E9C004E4843 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AD7244481DFF6E9C004E4843 /* AFHTTPSessionManager.m */; };
+		AD7244551DFF6E9C004E4843 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AD72444B1DFF6E9C004E4843 /* AFNetworkReachabilityManager.m */; };
+		AD7244561DFF6E9C004E4843 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = AD72444D1DFF6E9C004E4843 /* AFSecurityPolicy.m */; };
+		AD7244571DFF6E9C004E4843 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = AD72444F1DFF6E9C004E4843 /* AFURLRequestSerialization.m */; };
+		AD7244581DFF6E9C004E4843 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = AD7244511DFF6E9C004E4843 /* AFURLResponseSerialization.m */; };
+		AD7244591DFF6E9C004E4843 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AD7244531DFF6E9C004E4843 /* AFURLSessionManager.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -1366,27 +1364,12 @@
 		09F330341D46D37B002792BA /* mASocialFileViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mASocialFileViewController.h; sourceTree = "<group>"; };
 		09F330351D46D37B002792BA /* mASocialFileViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = mASocialFileViewController.m; sourceTree = "<group>"; };
 		09F330391D46D4AC002792BA /* mASocialFileViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = mASocialFileViewController.xib; sourceTree = "<group>"; };
-		09F3303D1D46DCDB002792BA /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPSessionManager.h; sourceTree = "<group>"; };
-		09F3303E1D46DCDB002792BA /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPSessionManager.m; sourceTree = "<group>"; };
-		09F3303F1D46DCDB002792BA /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
-		09F330401D46DCDB002792BA /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
-		09F330411D46DCDB002792BA /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
-		09F330421D46DCDB002792BA /* AFSecurityPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFSecurityPolicy.h; sourceTree = "<group>"; };
-		09F330431D46DCDB002792BA /* AFSecurityPolicy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFSecurityPolicy.m; sourceTree = "<group>"; };
-		09F330441D46DCDB002792BA /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLRequestSerialization.h; sourceTree = "<group>"; };
-		09F330451D46DCDB002792BA /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLRequestSerialization.m; sourceTree = "<group>"; };
-		09F330461D46DCDB002792BA /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLResponseSerialization.h; sourceTree = "<group>"; };
-		09F330471D46DCDB002792BA /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLResponseSerialization.m; sourceTree = "<group>"; };
-		09F330481D46DCDB002792BA /* AFURLSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLSessionManager.h; sourceTree = "<group>"; };
-		09F330491D46DCDB002792BA /* AFURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLSessionManager.m; sourceTree = "<group>"; };
 		09F3304A1D46DCDB002792BA /* ChuckPadSocial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ChuckPadSocial.h; sourceTree = "<group>"; };
 		09F3304B1D46DCDB002792BA /* ChuckPadSocial.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ChuckPadSocial.m; sourceTree = "<group>"; };
 		09F3304D1D46DCDB002792BA /* FXKeychain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FXKeychain.h; sourceTree = "<group>"; };
 		09F3304E1D46DCDB002792BA /* FXKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FXKeychain.m; sourceTree = "<group>"; };
-		09F3304F1D46DCDB002792BA /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		09F330501D46DCDB002792BA /* Patch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Patch.h; sourceTree = "<group>"; };
 		09F330511D46DCDB002792BA /* Patch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Patch.m; sourceTree = "<group>"; };
-		09F330521D46DCDB002792BA /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		09F330531D46DCDB002792BA /* User.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = User.h; sourceTree = "<group>"; };
 		09F330541D46DCDB002792BA /* User.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = User.m; sourceTree = "<group>"; };
 		09F330611D46DCE6002792BA /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
@@ -1418,6 +1401,19 @@
 		4D3D4C941A5E392800B6A06B /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		4D3D4C971A5E3A4400B6A06B /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
 		8D1107320486CEB800E47090 /* miniAudicle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = miniAudicle.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AD7244471DFF6E9C004E4843 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPSessionManager.h; sourceTree = "<group>"; };
+		AD7244481DFF6E9C004E4843 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPSessionManager.m; sourceTree = "<group>"; };
+		AD7244491DFF6E9C004E4843 /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
+		AD72444A1DFF6E9C004E4843 /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
+		AD72444B1DFF6E9C004E4843 /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
+		AD72444C1DFF6E9C004E4843 /* AFSecurityPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFSecurityPolicy.h; sourceTree = "<group>"; };
+		AD72444D1DFF6E9C004E4843 /* AFSecurityPolicy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFSecurityPolicy.m; sourceTree = "<group>"; };
+		AD72444E1DFF6E9C004E4843 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLRequestSerialization.h; sourceTree = "<group>"; };
+		AD72444F1DFF6E9C004E4843 /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLRequestSerialization.m; sourceTree = "<group>"; };
+		AD7244501DFF6E9C004E4843 /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLResponseSerialization.h; sourceTree = "<group>"; };
+		AD7244511DFF6E9C004E4843 /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLResponseSerialization.m; sourceTree = "<group>"; };
+		AD7244521DFF6E9C004E4843 /* AFURLSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLSessionManager.h; sourceTree = "<group>"; };
+		AD7244531DFF6E9C004E4843 /* AFURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLSessionManager.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2423,19 +2419,17 @@
 		09F3303B1D46DCDB002792BA /* chuckpad-social */ = {
 			isa = PBXGroup;
 			children = (
-				09F6F3AD1D4F21C500CC920C /* NSDate+Helper */,
 				09F3303C1D46DCDB002792BA /* AFNetworking */,
-				09F3304A1D46DCDB002792BA /* ChuckPadSocial.h */,
-				09F3304B1D46DCDB002792BA /* ChuckPadSocial.m */,
+				09F3304C1D46DCDB002792BA /* FXKeychain */,
+				09F6F3AD1D4F21C500CC920C /* NSDate+Helper */,
 				09CCA6671D4724360032EAB0 /* ChuckPadKeychain.h */,
 				09CCA6681D4724360032EAB0 /* ChuckPadKeychain.m */,
-				09F3304C1D46DCDB002792BA /* FXKeychain */,
-				09F3304F1D46DCDB002792BA /* LICENSE */,
+				09F3304A1D46DCDB002792BA /* ChuckPadSocial.h */,
+				09F3304B1D46DCDB002792BA /* ChuckPadSocial.m */,
 				09F330501D46DCDB002792BA /* Patch.h */,
 				09F330511D46DCDB002792BA /* Patch.m */,
 				09A2D6DA1D497AC100DD75F6 /* PatchCache.h */,
 				09A2D6DB1D497AC100DD75F6 /* PatchCache.m */,
-				09F330521D46DCDB002792BA /* README.md */,
 				09F330531D46DCDB002792BA /* User.h */,
 				09F330541D46DCDB002792BA /* User.m */,
 			);
@@ -2445,19 +2439,19 @@
 		09F3303C1D46DCDB002792BA /* AFNetworking */ = {
 			isa = PBXGroup;
 			children = (
-				09F3303D1D46DCDB002792BA /* AFHTTPSessionManager.h */,
-				09F3303E1D46DCDB002792BA /* AFHTTPSessionManager.m */,
-				09F3303F1D46DCDB002792BA /* AFNetworking.h */,
-				09F330401D46DCDB002792BA /* AFNetworkReachabilityManager.h */,
-				09F330411D46DCDB002792BA /* AFNetworkReachabilityManager.m */,
-				09F330421D46DCDB002792BA /* AFSecurityPolicy.h */,
-				09F330431D46DCDB002792BA /* AFSecurityPolicy.m */,
-				09F330441D46DCDB002792BA /* AFURLRequestSerialization.h */,
-				09F330451D46DCDB002792BA /* AFURLRequestSerialization.m */,
-				09F330461D46DCDB002792BA /* AFURLResponseSerialization.h */,
-				09F330471D46DCDB002792BA /* AFURLResponseSerialization.m */,
-				09F330481D46DCDB002792BA /* AFURLSessionManager.h */,
-				09F330491D46DCDB002792BA /* AFURLSessionManager.m */,
+				AD7244471DFF6E9C004E4843 /* AFHTTPSessionManager.h */,
+				AD7244481DFF6E9C004E4843 /* AFHTTPSessionManager.m */,
+				AD7244491DFF6E9C004E4843 /* AFNetworking.h */,
+				AD72444A1DFF6E9C004E4843 /* AFNetworkReachabilityManager.h */,
+				AD72444B1DFF6E9C004E4843 /* AFNetworkReachabilityManager.m */,
+				AD72444C1DFF6E9C004E4843 /* AFSecurityPolicy.h */,
+				AD72444D1DFF6E9C004E4843 /* AFSecurityPolicy.m */,
+				AD72444E1DFF6E9C004E4843 /* AFURLRequestSerialization.h */,
+				AD72444F1DFF6E9C004E4843 /* AFURLRequestSerialization.m */,
+				AD7244501DFF6E9C004E4843 /* AFURLResponseSerialization.h */,
+				AD7244511DFF6E9C004E4843 /* AFURLResponseSerialization.m */,
+				AD7244521DFF6E9C004E4843 /* AFURLSessionManager.h */,
+				AD7244531DFF6E9C004E4843 /* AFURLSessionManager.m */,
 			);
 			path = AFNetworking;
 			sourceTree = "<group>";
@@ -3021,7 +3015,6 @@
 				09735F441C870B2D003965CA /* ck-doc320.png in Resources */,
 				093E263614A108C9008694BC /* mADetailViewController~ipad.xib in Resources */,
 				09735F6F1C8A9407003965CA /* mAAudioFileTableViewCell.xib in Resources */,
-				09F3305D1D46DCDB002792BA /* LICENSE in Resources */,
 				09F09E5418E419960050D963 /* remove-noalpha.png in Resources */,
 				093E267914A14E91008694BC /* replace.png in Resources */,
 				09F0442C1918A8810028DD14 /* mALoopCountPicker.xib in Resources */,
@@ -3181,31 +3174,30 @@
 				093E263B14A12201008694BC /* uana_extract.cpp in Sources */,
 				092A171E1D481D7B00D74A09 /* mASocialLoginViewController.m in Sources */,
 				093E263C14A12201008694BC /* uana_xform.cpp in Sources */,
+				AD7244561DFF6E9C004E4843 /* AFSecurityPolicy.m in Sources */,
 				09F09E4918E3712D0050D963 /* mARoundedRectButton.m in Sources */,
 				093E263D14A12201008694BC /* chuck_absyn.cpp in Sources */,
 				0921D55E18190216008F39D9 /* bundle.c in Sources */,
 				09400F341C903FD400C1E52E /* KVOMutableArray.m in Sources */,
-				09F330561D46DCDB002792BA /* AFNetworkReachabilityManager.m in Sources */,
 				096D81051B40C1F800F9B9CA /* mAMasterViewController.m in Sources */,
 				09AC4E1818EA2C8500B2561A /* mAShredButton.m in Sources */,
 				09094DC419919E41009F4C4C /* mAActivityViewController.m in Sources */,
 				09307E2718E0BEC2004AB346 /* NSString+NSString_Lines.m in Sources */,
-				09F330581D46DCDB002792BA /* AFURLRequestSerialization.m in Sources */,
 				093E263E14A12201008694BC /* chuck_bbq.cpp in Sources */,
+				AD7244581DFF6E9C004E4843 /* AFURLResponseSerialization.m in Sources */,
 				093E263F14A12201008694BC /* chuck_compile.cpp in Sources */,
 				093E264014A12201008694BC /* chuck_console.cpp in Sources */,
 				09B596C019B02B2F0091D45F /* mAAutocomplete.cpp in Sources */,
 				09F330601D46DCDB002792BA /* User.m in Sources */,
 				093E264114A12201008694BC /* chuck_dl.cpp in Sources */,
 				093E264214A12201008694BC /* chuck_emit.cpp in Sources */,
-				09F3305A1D46DCDB002792BA /* AFURLSessionManager.m in Sources */,
 				0921D56C18190216008F39D9 /* timetag.c in Sources */,
 				093E264314A12201008694BC /* chuck_errmsg.cpp in Sources */,
 				099C04F818FBAF1400AC27C3 /* mANetworkAction.mm in Sources */,
 				093E264414A12201008694BC /* chuck_frame.cpp in Sources */,
 				093E264514A12201008694BC /* chuck_globals.cpp in Sources */,
-				09F330571D46DCDB002792BA /* AFSecurityPolicy.m in Sources */,
 				093E264614A12201008694BC /* chuck_instr.cpp in Sources */,
+				AD7244551DFF6E9C004E4843 /* AFNetworkReachabilityManager.m in Sources */,
 				093E264714A12201008694BC /* chuck_lang.cpp in Sources */,
 				093E264814A12201008694BC /* chuck_oo.cpp in Sources */,
 				09400F351C903FD400C1E52E /* KVOMutableArrayObserver.m in Sources */,
@@ -3216,6 +3208,7 @@
 				09094DC81991BC4A009F4C4C /* UIAlert.m in Sources */,
 				094B5F6719C9DBE0004B9B5E /* ulib_motion.mm in Sources */,
 				09F09E5818E41F2C0050D963 /* mADetailItem.mm in Sources */,
+				AD7244591DFF6E9C004E4843 /* AFURLSessionManager.m in Sources */,
 				09F3305E1D46DCDB002792BA /* Patch.m in Sources */,
 				093E264914A12201008694BC /* chuck_otf.cpp in Sources */,
 				093E264A14A12201008694BC /* chuck_parse.cpp in Sources */,
@@ -3254,7 +3247,6 @@
 				099C04F518FB715C00AC27C3 /* mANetworkManager.m in Sources */,
 				093E265714A12234008694BC /* hidio_sdl.cpp in Sources */,
 				0921D56218190216008F39D9 /* method.c in Sources */,
-				09F330551D46DCDB002792BA /* AFHTTPSessionManager.m in Sources */,
 				093E265814A12234008694BC /* midiio_rtmidi.cpp in Sources */,
 				093E265914A12234008694BC /* ugen_filter.cpp in Sources */,
 				093E265A14A12234008694BC /* ugen_osc.cpp in Sources */,
@@ -3278,7 +3270,6 @@
 				09F09E4C18E374C10050D963 /* mACGContext.c in Sources */,
 				09A14A1219B9AD5E00D28255 /* UIColor+iOS7BlueColor.m in Sources */,
 				09E9FE181D0CDC10002A2D63 /* mATableViewCell.m in Sources */,
-				09F330591D46DCDB002792BA /* AFURLResponseSerialization.m in Sources */,
 				09B596C119B0517D0091D45F /* NSString+STLString.mm in Sources */,
 				09CCA6731D4756730032EAB0 /* mASocialEditorViewController.m in Sources */,
 				093E266114A12234008694BC /* util_buffers.cpp in Sources */,
@@ -3291,7 +3282,6 @@
 				090261DF1D48AC83001B281D /* mASocialShareViewController.m in Sources */,
 				093E266614A12234008694BC /* util_opsc.cpp in Sources */,
 				093E266714A12234008694BC /* util_raw.c in Sources */,
-				09F3305F1D46DCDB002792BA /* README.md in Sources */,
 				09307E1F18DFB5E7004AB346 /* mASyntaxHighlighter.mm in Sources */,
 				093E266814A12234008694BC /* util_sndfile.c in Sources */,
 				09AB222F196FC4670037AF73 /* mADocumentManager.m in Sources */,
@@ -3301,6 +3291,7 @@
 				093E266B14A12234008694BC /* util_xforms.c in Sources */,
 				09F09E3718E0F5AE0050D963 /* mAKeyboardButton.m in Sources */,
 				093E266F14A12240008694BC /* miniAudicle.cpp in Sources */,
+				AD7244541DFF6E9C004E4843 /* AFHTTPSessionManager.m in Sources */,
 				0921D56818190216008F39D9 /* server.c in Sources */,
 				093E267014A12240008694BC /* miniAudicle_log.cpp in Sources */,
 				093E267814A12E3C008694BC /* mo_audio.mm in Sources */,
@@ -3310,6 +3301,7 @@
 				0985624F1CE7FE1F00FCBF21 /* mAFolderTableViewCell.m in Sources */,
 				096BFF811CD363C6006653F5 /* mAPreferences.m in Sources */,
 				09D00B8B14A44DFB0019CD09 /* mAVMMonitorController.mm in Sources */,
+				AD7244571DFF6E9C004E4843 /* AFURLRequestSerialization.m in Sources */,
 				09F3305B1D46DCDB002792BA /* ChuckPadSocial.m in Sources */,
 				09087C6514A4F5F600AD2633 /* mAVMMonitorCellController.mm in Sources */,
 				09608ADF14B40DE4009450FE /* mAConsoleMonitorController.mm in Sources */,


### PR DESCRIPTION
Updating submodule chuckpad-social to the latest version. This version includes a bunch of bug fixes and the "extraData" parameter for patches which allows arbitrary data to be associated with a patch. 