### PR TITLE
fix issue 25: change file extension on format select

### DIFF
--- a/src/macosx/NSPanel+ButtonTag.h
+++ b/src/macosx/NSPanel+ButtonTag.h
@@ -1,0 +1,16 @@
+//
+//  NSPanel+ButtonTag.h
+//  miniAudicle
+//
+//  Created by leanne on 1/11/17.
+//
+//
+
+#import <AppKit/AppKit.h>
+
+@interface NSPanel (ButtonTag)
+
+- (int)tagForButtonWithTitle:(NSString *)title;
+- (void)setTag:(int)tagValue forButtonWithTitle:(NSString *)title;
+
+@end

--- a/src/macosx/NSPanel+ButtonTag.h
+++ b/src/macosx/NSPanel+ButtonTag.h
@@ -12,5 +12,7 @@
 
 - (int)tagForButtonWithTitle:(NSString *)title;
 - (void)setTag:(int)tagValue forButtonWithTitle:(NSString *)title;
+- (void)enableButtonWithTag:(int)tagValue;
+- (void)disableButtonWithTag:(int)tagValue;
 
 @end

--- a/src/macosx/NSPanel+ButtonTag.m
+++ b/src/macosx/NSPanel+ButtonTag.m
@@ -4,7 +4,7 @@
 //
 //  Created by leanne on 1/11/17.
 //
-//
+
 
 #import "NSPanel+ButtonTag.h"
 
@@ -12,7 +12,6 @@
 
 - (int)tagForButtonWithTitle:(NSString *)title
 {
-    // set tag on panel's "Export" button (panel -> subview -> sub-subview level)
     NSArray *panelLevel1Views = self.contentView.subviews;
     
     for (NSView *level1View in panelLevel1Views) {
@@ -33,12 +32,11 @@
         }
     }
     
-    return -1;
+    return 0;
 }
 
 - (void)setTag:(int)tagValue forButtonWithTitle:(NSString *)title
 {
-    // set tag on panel's "Export" button (panel -> subview -> sub-subview level)
     NSArray *panelLevel1Views = self.contentView.subviews;
     BOOL canStopNow = false;
     
@@ -62,6 +60,24 @@
         
         if (canStopNow) { break; }
     }
+}
+
+- (void)enableButtonWithTag:(int)tagValue
+{
+    NSButton *taggedButton = [self.contentView viewWithTag: tagValue];
+    BOOL taggedButtonAvailable = (taggedButton != nil);
+    
+    if (taggedButtonAvailable) { taggedButton.enabled = YES; }
+
+}
+
+- (void)disableButtonWithTag:(int)tagValue
+{
+    NSButton *taggedButton = [self.contentView viewWithTag: tagValue];
+    BOOL taggedButtonAvailable = (taggedButton != nil);
+    
+    if (taggedButtonAvailable) { taggedButton.enabled = NO; }
+    
 }
 
 @end

--- a/src/macosx/NSPanel+ButtonTag.m
+++ b/src/macosx/NSPanel+ButtonTag.m
@@ -1,0 +1,67 @@
+//
+//  NSPanel+ButtonTag.m
+//  miniAudicle
+//
+//  Created by leanne on 1/11/17.
+//
+//
+
+#import "NSPanel+ButtonTag.h"
+
+@implementation NSPanel (ButtonTag)
+
+- (int)tagForButtonWithTitle:(NSString *)title
+{
+    // set tag on panel's "Export" button (panel -> subview -> sub-subview level)
+    NSArray *panelLevel1Views = self.contentView.subviews;
+    
+    for (NSView *level1View in panelLevel1Views) {
+        
+        NSArray *level2Views = level1View.subviews;
+        
+        for (NSView *level2View in level2Views) {
+            
+            if ([level2View isKindOfClass:NSButton.class]) {
+                
+                NSString *btnTitle = ((NSButton *)level2View).title;
+                
+                if ([btnTitle  isEqual: title]) {
+                    int tag = (NSButton *)level2View.tag;
+                    return tag;
+                }
+            }
+        }
+    }
+    
+    return -1;
+}
+
+- (void)setTag:(int)tagValue forButtonWithTitle:(NSString *)title
+{
+    // set tag on panel's "Export" button (panel -> subview -> sub-subview level)
+    NSArray *panelLevel1Views = self.contentView.subviews;
+    BOOL canStopNow = false;
+    
+    for (NSView *level1View in panelLevel1Views) {
+        
+        NSArray *level2Views = level1View.subviews;
+        
+        for (NSView *level2View in level2Views) {
+            
+            if ([level2View isKindOfClass:NSButton.class]) {
+                
+                NSString *btnTitle = ((NSButton *)level2View).title;
+                
+                if ([btnTitle  isEqual: title]) {
+                    [(NSButton *)level2View setTag:tagValue];
+                    canStopNow = true;
+                    break;
+                }
+            }
+        }
+        
+        if (canStopNow) { break; }
+    }
+}
+
+@end

--- a/src/macosx/Resources/English.lproj/mAExportAs.xib
+++ b/src/macosx/Resources/English.lproj/mAExportAs.xib
@@ -1,732 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1050</int>
-		<string key="IBDocument.SystemVersion">12E55</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.39</string>
-		<string key="IBDocument.HIToolboxVersion">626.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">3084</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSNumberFormatter</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-			<string>NSUserDefaultsController</string>
-			<string>NSView</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<object class="NSCustomObject" id="1001">
-				<string key="NSClassName">mAExportAsViewController</string>
-			</object>
-			<object class="NSCustomObject" id="1003">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="1004">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSNumberFormatter" id="717711142">
-				<dictionary class="NSMutableDictionary" key="NS.attributes">
-					<boolean value="YES" key="allowsFloats"/>
-					<boolean value="NO" key="alwaysShowsDecimalSeparator"/>
-					<integer value="1040" key="formatterBehavior"/>
-					<string key="groupingSeparator">,</string>
-					<boolean value="NO" key="lenient"/>
-					<object class="NSLocale" key="locale">
-						<string key="NS.identifier"/>
-					</object>
-					<integer value="4" key="maximumFractionDigits"/>
-					<integer value="0" key="minimum"/>
-					<integer value="1" key="minimumFractionDigits"/>
-					<string key="negativeInfinitySymbol">-∞</string>
-					<string key="nilSymbol"/>
-					<integer value="1" key="numberStyle"/>
-					<string key="positiveInfinitySymbol">+∞</string>
-					<boolean value="NO" key="usesGroupingSeparator"/>
-				</dictionary>
-				<string key="NS.positiveformat">#0.0###</string>
-				<string key="NS.negativeformat">#0.0###</string>
-				<nil key="NS.positiveattrs"/>
-				<nil key="NS.negativeattrs"/>
-				<nil key="NS.zero"/>
-				<object class="NSAttributedString" key="NS.nil">
-					<string key="NSString"/>
-				</object>
-				<object class="NSAttributedString" key="NS.nan">
-					<string key="NSString">NaN</string>
-					<dictionary key="NSAttributes"/>
-				</object>
-				<integer value="0" key="NS.min"/>
-				<object class="NSDecimalNumberPlaceholder" key="NS.max">
-					<int key="NS.exponent">0</int>
-					<int key="NS.length">0</int>
-					<bool key="NS.negative">YES</bool>
-					<bool key="NS.compact">NO</bool>
-					<int key="NS.mantissa.bo">1</int>
-					<bytes key="NS.mantissa">AAAAAAAAAAAAAAAAAAAAAA</bytes>
-				</object>
-				<object class="NSDecimalNumberHandler" key="NS.rounding">
-					<int key="NS.roundingmode">3</int>
-					<bool key="NS.raise.overflow">YES</bool>
-					<bool key="NS.raise.underflow">YES</bool>
-					<bool key="NS.raise.dividebyzero">YES</bool>
-				</object>
-				<string key="NS.decimal">.</string>
-				<string key="NS.thousand">,</string>
-				<bool key="NS.hasthousands">NO</bool>
-				<bool key="NS.localized">NO</bool>
-				<bool key="NS.allowsfloats">YES</bool>
-			</object>
-			<object class="NSView" id="420325008">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">266</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="NSTextField" id="452153757">
-						<reference key="NSNextResponder" ref="420325008"/>
-						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{156, 65}, {67, 22}}</string>
-						<reference key="NSSuperview" ref="420325008"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="277488489"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="357134378">
-							<int key="NSCellFlags">-1804599231</int>
-							<int key="NSCellFlags2">71304192</int>
-							<string key="NSContents">30.0</string>
-							<object class="NSFont" key="NSSupport" id="254428789">
-								<string key="NSName">LucidaGrande</string>
-								<double key="NSSize">13</double>
-								<int key="NSfFlags">1044</int>
-							</object>
-							<string key="NSCellIdentifier">_NS:9</string>
-							<reference key="NSControlView" ref="452153757"/>
-							<bool key="NSDrawsBackground">YES</bool>
-							<object class="NSColor" key="NSBackgroundColor">
-								<int key="NSColorSpace">6</int>
-								<string key="NSCatalogName">System</string>
-								<string key="NSColorName">textBackgroundColor</string>
-								<object class="NSColor" key="NSColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MQA</bytes>
-								</object>
-							</object>
-							<object class="NSColor" key="NSTextColor">
-								<int key="NSColorSpace">6</int>
-								<string key="NSCatalogName">System</string>
-								<string key="NSColorName">textColor</string>
-								<object class="NSColor" key="NSColor" id="540546979">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MAA</bytes>
-								</object>
-							</object>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSTextField" id="277488489">
-						<reference key="NSNextResponder" ref="420325008"/>
-						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{228, 67}, {56, 17}}</string>
-						<reference key="NSSuperview" ref="420325008"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="757703309"/>
-						<string key="NSReuseIdentifierKey">_NS:1535</string>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="598099188">
-							<int key="NSCellFlags">68157504</int>
-							<int key="NSCellFlags2">272630784</int>
-							<string key="NSContents">seconds</string>
-							<reference key="NSSupport" ref="254428789"/>
-							<string key="NSCellIdentifier">_NS:1535</string>
-							<reference key="NSControlView" ref="277488489"/>
-							<object class="NSColor" key="NSBackgroundColor" id="616673587">
-								<int key="NSColorSpace">6</int>
-								<string key="NSCatalogName">System</string>
-								<string key="NSColorName">controlColor</string>
-								<object class="NSColor" key="NSColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-								</object>
-							</object>
-							<object class="NSColor" key="NSTextColor" id="643902586">
-								<int key="NSColorSpace">6</int>
-								<string key="NSCatalogName">System</string>
-								<string key="NSColorName">controlTextColor</string>
-								<reference key="NSColor" ref="540546979"/>
-							</object>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSButton" id="155900977">
-						<reference key="NSNextResponder" ref="420325008"/>
-						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{18, 66}, {132, 18}}</string>
-						<reference key="NSSuperview" ref="420325008"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="452153757"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="365711021">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">268435456</int>
-							<string key="NSContents">Limit duration to:</string>
-							<reference key="NSSupport" ref="254428789"/>
-							<string key="NSCellIdentifier">_NS:9</string>
-							<reference key="NSControlView" ref="155900977"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<object class="NSCustomResource" key="NSNormalImage" id="868810501">
-								<string key="NSClassName">NSImage</string>
-								<string key="NSResourceName">NSSwitch</string>
-							</object>
-							<object class="NSButtonImageSource" key="NSAlternateImage" id="776378882">
-								<string key="NSImageName">NSSwitch</string>
-							</object>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSButton" id="119771259">
-						<reference key="NSNextResponder" ref="420325008"/>
-						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{136, 38}, {51, 18}}</string>
-						<reference key="NSSuperview" ref="420325008"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="247323613"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="187839929">
-							<int key="NSCellFlags">-2080374784</int>
-							<int key="NSCellFlags2">268435456</int>
-							<string key="NSContents">WAV</string>
-							<reference key="NSSupport" ref="254428789"/>
-							<string key="NSCellIdentifier">_NS:9</string>
-							<reference key="NSControlView" ref="119771259"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="868810501"/>
-							<reference key="NSAlternateImage" ref="776378882"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSTextField" id="757703309">
-						<reference key="NSNextResponder" ref="420325008"/>
-						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{17, 40}, {114, 17}}</string>
-						<reference key="NSSuperview" ref="420325008"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="119771259"/>
-						<string key="NSReuseIdentifierKey">_NS:1535</string>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="371664205">
-							<int key="NSCellFlags">68157504</int>
-							<int key="NSCellFlags2">272630784</int>
-							<string key="NSContents">Output format(s):</string>
-							<reference key="NSSupport" ref="254428789"/>
-							<string key="NSCellIdentifier">_NS:1535</string>
-							<reference key="NSControlView" ref="757703309"/>
-							<reference key="NSBackgroundColor" ref="616673587"/>
-							<reference key="NSTextColor" ref="643902586"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSButton" id="247323613">
-						<reference key="NSNextResponder" ref="420325008"/>
-						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{207, 38}, {93, 18}}</string>
-						<reference key="NSSuperview" ref="420325008"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="189885503"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="176490492">
-							<int key="NSCellFlags">-2080374784</int>
-							<int key="NSCellFlags2">268435456</int>
-							<string key="NSContents">Ogg Vorbis</string>
-							<reference key="NSSupport" ref="254428789"/>
-							<string key="NSCellIdentifier">_NS:9</string>
-							<reference key="NSControlView" ref="247323613"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="868810501"/>
-							<reference key="NSAlternateImage" ref="776378882"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSButton" id="189885503">
-						<reference key="NSNextResponder" ref="420325008"/>
-						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{136, 18}, {51, 18}}</string>
-						<reference key="NSSuperview" ref="420325008"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="772910190"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="419732650">
-							<int key="NSCellFlags">-2080374784</int>
-							<int key="NSCellFlags2">268435456</int>
-							<string key="NSContents">M4A</string>
-							<reference key="NSSupport" ref="254428789"/>
-							<string key="NSCellIdentifier">_NS:9</string>
-							<reference key="NSControlView" ref="189885503"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="868810501"/>
-							<reference key="NSAlternateImage" ref="776378882"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSButton" id="772910190">
-						<reference key="NSNextResponder" ref="420325008"/>
-						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{207, 18}, {49, 18}}</string>
-						<reference key="NSSuperview" ref="420325008"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="36577487">
-							<int key="NSCellFlags">-2080374784</int>
-							<int key="NSCellFlags2">268435456</int>
-							<string key="NSContents">MP3</string>
-							<reference key="NSSupport" ref="254428789"/>
-							<string key="NSCellIdentifier">_NS:9</string>
-							<reference key="NSControlView" ref="772910190"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="868810501"/>
-							<reference key="NSAlternateImage" ref="776378882"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-				</array>
-				<string key="NSFrameSize">{318, 105}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="155900977"/>
-			</object>
-			<object class="NSUserDefaultsController" id="789615847">
-				<bool key="NSSharedInstance">YES</bool>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">view</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="420325008"/>
-					</object>
-					<int key="connectionID">14</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">_durationTextField</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="452153757"/>
-					</object>
-					<int key="connectionID">35</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">formatter</string>
-						<reference key="source" ref="452153757"/>
-						<reference key="destination" ref="717711142"/>
-					</object>
-					<int key="connectionID">13</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: self.duration</string>
-						<reference key="source" ref="452153757"/>
-						<reference key="destination" ref="1001"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="452153757"/>
-							<reference key="NSDestination" ref="1001"/>
-							<string key="NSLabel">value: self.duration</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">self.duration</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">32</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">enabled: self.limitDuration</string>
-						<reference key="source" ref="452153757"/>
-						<reference key="destination" ref="1001"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="452153757"/>
-							<reference key="NSDestination" ref="1001"/>
-							<string key="NSLabel">enabled: self.limitDuration</string>
-							<string key="NSBinding">enabled</string>
-							<string key="NSKeyPath">self.limitDuration</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">34</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: self.limitDuration</string>
-						<reference key="source" ref="155900977"/>
-						<reference key="destination" ref="1001"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="155900977"/>
-							<reference key="NSDestination" ref="1001"/>
-							<string key="NSLabel">value: self.limitDuration</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">self.limitDuration</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">29</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: self.exportWAV</string>
-						<reference key="source" ref="119771259"/>
-						<reference key="destination" ref="1001"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="119771259"/>
-							<reference key="NSDestination" ref="1001"/>
-							<string key="NSLabel">value: self.exportWAV</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">self.exportWAV</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">53</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: self.exportOgg</string>
-						<reference key="source" ref="247323613"/>
-						<reference key="destination" ref="1001"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="247323613"/>
-							<reference key="NSDestination" ref="1001"/>
-							<string key="NSLabel">value: self.exportOgg</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">self.exportOgg</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">56</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: self.exportM4A</string>
-						<reference key="source" ref="189885503"/>
-						<reference key="destination" ref="1001"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="189885503"/>
-							<reference key="NSDestination" ref="1001"/>
-							<string key="NSLabel">value: self.exportM4A</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">self.exportM4A</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">59</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: self.exportMP3</string>
-						<reference key="source" ref="772910190"/>
-						<reference key="destination" ref="1001"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="772910190"/>
-							<reference key="NSDestination" ref="1001"/>
-							<string key="NSLabel">value: self.exportMP3</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">self.exportMP3</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">62</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">hidden: self.enableMP3</string>
-						<reference key="source" ref="772910190"/>
-						<reference key="destination" ref="1001"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="772910190"/>
-							<reference key="NSDestination" ref="1001"/>
-							<string key="NSLabel">hidden: self.enableMP3</string>
-							<string key="NSBinding">hidden</string>
-							<string key="NSKeyPath">self.enableMP3</string>
-							<object class="NSDictionary" key="NSOptions">
-								<string key="NS.key.0">NSValueTransformerName</string>
-								<string key="NS.object.0">NSNegateBoolean</string>
-							</object>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">65</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="1001"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="1003"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="1004"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">3</int>
-						<reference key="object" ref="420325008"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="155900977"/>
-							<reference ref="452153757"/>
-							<reference ref="277488489"/>
-							<reference ref="757703309"/>
-							<reference ref="119771259"/>
-							<reference ref="247323613"/>
-							<reference ref="189885503"/>
-							<reference ref="772910190"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">6</int>
-						<reference key="object" ref="452153757"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="357134378"/>
-						</array>
-						<reference key="parent" ref="420325008"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">7</int>
-						<reference key="object" ref="357134378"/>
-						<reference key="parent" ref="452153757"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">8</int>
-						<reference key="object" ref="277488489"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="598099188"/>
-						</array>
-						<reference key="parent" ref="420325008"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">9</int>
-						<reference key="object" ref="598099188"/>
-						<reference key="parent" ref="277488489"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">10</int>
-						<reference key="object" ref="717711142"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">15</int>
-						<reference key="object" ref="155900977"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="365711021"/>
-						</array>
-						<reference key="parent" ref="420325008"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">16</int>
-						<reference key="object" ref="365711021"/>
-						<reference key="parent" ref="155900977"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">36</int>
-						<reference key="object" ref="119771259"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="187839929"/>
-						</array>
-						<reference key="parent" ref="420325008"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">37</int>
-						<reference key="object" ref="187839929"/>
-						<reference key="parent" ref="119771259"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">38</int>
-						<reference key="object" ref="757703309"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="371664205"/>
-						</array>
-						<reference key="parent" ref="420325008"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">39</int>
-						<reference key="object" ref="371664205"/>
-						<reference key="parent" ref="757703309"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">44</int>
-						<reference key="object" ref="247323613"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="176490492"/>
-						</array>
-						<reference key="parent" ref="420325008"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">45</int>
-						<reference key="object" ref="176490492"/>
-						<reference key="parent" ref="247323613"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">46</int>
-						<reference key="object" ref="189885503"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="419732650"/>
-						</array>
-						<reference key="parent" ref="420325008"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">47</int>
-						<reference key="object" ref="419732650"/>
-						<reference key="parent" ref="189885503"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">48</int>
-						<reference key="object" ref="772910190"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="36577487"/>
-						</array>
-						<reference key="parent" ref="420325008"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">49</int>
-						<reference key="object" ref="36577487"/>
-						<reference key="parent" ref="772910190"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">50</int>
-						<reference key="object" ref="789615847"/>
-						<reference key="parent" ref="0"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<integer value="1040" key="10.IBNumberFormatterBehaviorMetadataKey"/>
-				<boolean value="NO" key="10.IBNumberFormatterLocalizesFormatMetadataKey"/>
-				<real value="1234.75" key="10.IBNumberFormatterSampleNumberKey"/>
-				<string key="10.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="15.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="16.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="36.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="37.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="38.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="39.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="44.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="45.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="46.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="47.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="48.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="49.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="50.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="7.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="8.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="9.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">65</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">mAExportAsViewController</string>
-					<string key="superclassName">NSViewController</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">_durationTextField</string>
-						<string key="NS.object.0">NSTextField</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">_durationTextField</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">_durationTextField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/mAExportAsViewController.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1050" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<real value="3200" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<object class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="NS.key.0">NSSwitch</string>
-			<string key="NS.object.0">{15, 15}</string>
-		</object>
-	</data>
-</archive>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="16C67" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <deployment version="1050" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="mAExportAsViewController">
+            <connections>
+                <outlet property="_durationTextField" destination="6" id="35"/>
+                <outlet property="view" destination="3" id="14"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <numberFormatter formatterBehavior="custom10_4" localizesFormat="NO" numberStyle="decimal" usesGroupingSeparator="NO" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" minimumFractionDigits="1" maximumFractionDigits="4" groupingSeparator="," id="10">
+            <integer key="minimum" value="0"/>
+        </numberFormatter>
+        <view id="3">
+            <rect key="frame" x="0.0" y="0.0" width="318" height="105"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" id="6">
+                    <rect key="frame" x="156" y="65" width="67" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="30.0" drawsBackground="YES" id="7">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="-2" name="enabled" keyPath="self.limitDuration" id="34"/>
+                        <binding destination="-2" name="value" keyPath="self.duration" id="32"/>
+                        <outlet property="formatter" destination="10" id="13"/>
+                    </connections>
+                </textField>
+                <textField verticalHuggingPriority="750" id="8">
+                    <rect key="frame" x="228" y="67" width="56" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="seconds" id="9">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button id="15">
+                    <rect key="frame" x="18" y="66" width="132" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Limit duration to:" bezelStyle="regularSquare" imagePosition="left" inset="2" id="16">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="-2" name="value" keyPath="self.limitDuration" id="29"/>
+                    </connections>
+                </button>
+                <button id="36">
+                    <rect key="frame" x="136" y="38" width="51" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="WAV" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="37">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="formatButtonClick:" target="-2" id="Eqs-iy-cqH"/>
+                        <binding destination="-2" name="value" keyPath="self.exportWAV" id="53"/>
+                    </connections>
+                </button>
+                <textField verticalHuggingPriority="750" id="38">
+                    <rect key="frame" x="17" y="40" width="114" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Output format(s):" id="39">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button id="44">
+                    <rect key="frame" x="207" y="38" width="93" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Ogg Vorbis" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="45">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="formatButtonClick:" target="-2" id="DEW-rj-gcp"/>
+                        <binding destination="-2" name="value" keyPath="self.exportOgg" id="56"/>
+                    </connections>
+                </button>
+                <button id="46">
+                    <rect key="frame" x="136" y="18" width="51" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="M4A" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="47">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="formatButtonClick:" target="-2" id="C9N-dr-F3j"/>
+                        <binding destination="-2" name="value" keyPath="self.exportM4A" id="59"/>
+                    </connections>
+                </button>
+                <button id="48">
+                    <rect key="frame" x="207" y="18" width="49" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="MP3" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="49">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="formatButtonClick:" target="-2" id="0BJ-Pj-40s"/>
+                        <binding destination="-2" name="hidden" keyPath="self.enableMP3" id="65">
+                            <dictionary key="options">
+                                <string key="NSValueTransformerName">NSNegateBoolean</string>
+                            </dictionary>
+                        </binding>
+                        <binding destination="-2" name="value" keyPath="self.exportMP3" id="62"/>
+                    </connections>
+                </button>
+            </subviews>
+        </view>
+        <userDefaultsController representsSharedInstance="YES" id="50"/>
+    </objects>
+</document>

--- a/src/macosx/mAExportAsViewController.h
+++ b/src/macosx/mAExportAsViewController.h
@@ -60,6 +60,7 @@
 @property (nonatomic) BOOL enableMP3;
 
 - (IBAction)formatButtonClick:(id)sender;
+- (void)configureSavePanelForSelectedFormats;
 - (void)saveSettings;
 
 @end

--- a/src/macosx/mAExportAsViewController.h
+++ b/src/macosx/mAExportAsViewController.h
@@ -43,6 +43,8 @@
     IBOutlet NSTextField * _durationTextField;
 }
 
+@property (nonatomic, assign) NSSavePanel *savePanel;
+
 @property (nonatomic) BOOL limitDuration;
 @property (nonatomic) CGFloat duration;
 
@@ -53,6 +55,7 @@
 
 @property (nonatomic) BOOL enableMP3;
 
+- (IBAction)formatButtonClick:(id)sender;
 - (void)saveSettings;
 
 @end

--- a/src/macosx/mAExportAsViewController.h
+++ b/src/macosx/mAExportAsViewController.h
@@ -34,13 +34,13 @@
 
 @interface mAExportAsViewController : NSViewController
 {
-    BOOL limitDuration;
-    CGFloat duration;
-    
-    BOOL exportWAV, exportOgg, exportM4A, exportMP3;
-    BOOL enableMP3;
-    
-    IBOutlet NSTextField * _durationTextField;
+	BOOL limitDuration;
+	CGFloat duration;
+	
+	BOOL exportWAV, exportOgg, exportM4A, exportMP3;
+	BOOL enableMP3;
+	
+	IBOutlet NSTextField * _durationTextField;
 }
 
 @property (nonatomic, assign) NSSavePanel *savePanel;

--- a/src/macosx/mAExportAsViewController.h
+++ b/src/macosx/mAExportAsViewController.h
@@ -46,6 +46,8 @@
 @property (nonatomic, assign) NSSavePanel *savePanel;
 @property (nonatomic) int exportButtonTag;
 
+@property (nonatomic, readonly) int numSelectedFileTypes;
+
 @property (nonatomic) BOOL limitDuration;
 @property (nonatomic) CGFloat duration;
 

--- a/src/macosx/mAExportAsViewController.h
+++ b/src/macosx/mAExportAsViewController.h
@@ -43,8 +43,9 @@
 	IBOutlet NSTextField * _durationTextField;
 }
 
-@property (nonatomic, assign) NSSavePanel *savePanel;
+@property (nonatomic, assign) NSSavePanel * savePanel;
 @property (nonatomic) int exportButtonTag;
+@property (nonatomic, readonly) NSString * noSelectedFormatsMessage;
 
 @property (nonatomic, readonly) int numSelectedFileTypes;
 

--- a/src/macosx/mAExportAsViewController.h
+++ b/src/macosx/mAExportAsViewController.h
@@ -44,6 +44,7 @@
 }
 
 @property (nonatomic, assign) NSSavePanel *savePanel;
+@property (nonatomic) int exportButtonTag;
 
 @property (nonatomic) BOOL limitDuration;
 @property (nonatomic) CGFloat duration;

--- a/src/macosx/mAExportAsViewController.m
+++ b/src/macosx/mAExportAsViewController.m
@@ -141,7 +141,7 @@ static BOOL g_lameAvailable = NO;
 {
 	switch (self.numSelectedFileTypes) {
 		case 0:
-			[savePanel setAllowedFileTypes:@[@""]];
+			[savePanel setAllowedFileTypes:nil];
 			[savePanel disableButtonWithTag:exportButtonTag];
 			savePanel.message = noSelectedFormatsMessage;
 			break;

--- a/src/macosx/mAExportAsViewController.m
+++ b/src/macosx/mAExportAsViewController.m
@@ -134,15 +134,20 @@ static BOOL g_lameAvailable = NO;
  */
 - (IBAction)formatButtonClick:(id)sender
 {
-    switch (self.numSelectedFileTypes) {
+	[self configureSavePanelForSelectedFormats];
+}
+
+- (void)configureSavePanelForSelectedFormats
+{
+	switch (self.numSelectedFileTypes) {
 		case 0:
 			[savePanel setAllowedFileTypes:@[@""]];
-            [savePanel disableButtonWithTag:exportButtonTag];
-            savePanel.message = noSelectedFormatsMessage;
+			[savePanel disableButtonWithTag:exportButtonTag];
+			savePanel.message = noSelectedFormatsMessage;
 			break;
 			
 		case 1:
-            [savePanel enableButtonWithTag:exportButtonTag];
+			[savePanel enableButtonWithTag:exportButtonTag];
 			if (self.exportWAV) {
 				[savePanel setAllowedFileTypes:@[@"wav"]];
 			}
@@ -155,13 +160,13 @@ static BOOL g_lameAvailable = NO;
 			else if (self.exportMP3) {
 				[savePanel setAllowedFileTypes:@[@"mp3"]];
 			}
-            savePanel.message = @"";
+			savePanel.message = @"";
 			break;
 			
 		default:
-            [savePanel enableButtonWithTag:exportButtonTag];
+			[savePanel enableButtonWithTag:exportButtonTag];
 			[savePanel setAllowedFileTypes:@[@"*"]];
-            savePanel.message = @"";
+			savePanel.message = @"";
 			break;
 	}
 }

--- a/src/macosx/mAExportAsViewController.m
+++ b/src/macosx/mAExportAsViewController.m
@@ -45,12 +45,17 @@ static BOOL g_lameAvailable = NO;
 
 @interface mAExportAsViewController ()
 
+@property (nonatomic, readwrite) NSString * noSelectedFormatsMessage;
+
+
 @end
 
 @implementation mAExportAsViewController
 
 @synthesize savePanel;
 @synthesize exportButtonTag;
+@synthesize noSelectedFormatsMessage;
+
 @synthesize numSelectedFileTypes;
 
 @synthesize limitDuration, duration;
@@ -100,6 +105,7 @@ static BOOL g_lameAvailable = NO;
 	self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
 	if (self)
 	{
+        self.noSelectedFormatsMessage = @"REQUIRED: Select format(s) for export.";
 	}
 	
 	return self;
@@ -132,7 +138,7 @@ static BOOL g_lameAvailable = NO;
 		case 0:
 			[savePanel setAllowedFileTypes:@[@""]];
             [savePanel disableButtonWithTag:exportButtonTag];
-            savePanel.message = @"REQUIRED: select a format for the export.";
+            savePanel.message = noSelectedFormatsMessage;
 			break;
 			
 		case 1:

--- a/src/macosx/mAExportAsViewController.m
+++ b/src/macosx/mAExportAsViewController.m
@@ -32,6 +32,7 @@
 
 #import "mAExportAsViewController.h"
 #import "mADocumentExporter.h"
+#import "NSPanel+ButtonTag.h"
 
 NSString * const mAExportAsLimitDuration = @"mAExportAsLimitDuration";
 NSString * const mAExportAsDuration = @"mAExportAsDuration";
@@ -43,8 +44,6 @@ NSString * const mAExportAsExportMP3 = @"mAExportAsExportMP3";
 static BOOL g_lameAvailable = NO;
 
 @interface mAExportAsViewController ()
-
-@property (nonatomic) int numSelectedFileTypes;
 
 @end
 
@@ -72,10 +71,10 @@ static BOOL g_lameAvailable = NO;
 															  }];
     
     // unremark to set defaults for testing //
-//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportWAV];
-//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportOgg];
-//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportM4A];
-//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportMP3];
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportWAV];
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportOgg];
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportM4A];
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportMP3];
     // end unremark to set defaults for testing //
 }
 
@@ -129,25 +128,15 @@ static BOOL g_lameAvailable = NO;
  */
 - (IBAction)formatButtonClick:(id)sender
 {
-	NSButton *exportButton = [savePanel.contentView viewWithTag: exportButtonTag];
-	BOOL exportButtonAvailable = (exportButton != nil);
-	
-	if (exportButtonAvailable && self.numSelectedFileTypes > 0) {
-        savePanel.message = @"";
-        exportButton.enabled = YES;
-	}
-	
-	switch (self.numSelectedFileTypes) {
+    switch (self.numSelectedFileTypes) {
 		case 0:
 			[savePanel setAllowedFileTypes:@[@""]];
-			
-			if (exportButtonAvailable) {
-				savePanel.message = @"REQUIRED: one or more export types must be selected";
-				exportButton.enabled = NO;
-			}
+            [savePanel disableButtonWithTag:exportButtonTag];
+            savePanel.message = @"REQUIRED: select a format for the export.";
 			break;
 			
 		case 1:
+            [savePanel enableButtonWithTag:exportButtonTag];
 			if (self.exportWAV) {
 				[savePanel setAllowedFileTypes:@[@"wav"]];
 			}
@@ -160,10 +149,13 @@ static BOOL g_lameAvailable = NO;
 			else if (self.exportMP3) {
 				[savePanel setAllowedFileTypes:@[@"mp3"]];
 			}
+            savePanel.message = @"";
 			break;
 			
 		default:
+            [savePanel enableButtonWithTag:exportButtonTag];
 			[savePanel setAllowedFileTypes:@[@"*"]];
+            savePanel.message = @"";
 			break;
 	}
 }

--- a/src/macosx/mAExportAsViewController.m
+++ b/src/macosx/mAExportAsViewController.m
@@ -76,10 +76,10 @@ static BOOL g_lameAvailable = NO;
 															  }];
     
     // unremark to set defaults for testing //
-    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportWAV];
-    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportOgg];
-    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportM4A];
-    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportMP3];
+//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportWAV];
+//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportOgg];
+//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportM4A];
+//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportMP3];
     // end unremark to set defaults for testing //
 }
 

--- a/src/macosx/mAExportAsViewController.m
+++ b/src/macosx/mAExportAsViewController.m
@@ -61,57 +61,57 @@ static BOOL g_lameAvailable = NO;
 + (void)initialize
 {
 	g_lameAvailable = (which(@"lame") != nil);
-    
-    [[NSUserDefaults standardUserDefaults] registerDefaults:@{
-                                    mAExportAsLimitDuration: @NO,
-                                         mAExportAsDuration: @30.0,
-                                        mAExportAsExportWAV: @YES,
-                                        mAExportAsExportOgg: @NO,
-                                        mAExportAsExportM4A: @NO,
-                                        mAExportAsExportMP3: @NO,
-     }];
+	
+	[[NSUserDefaults standardUserDefaults] registerDefaults:@{
+															  mAExportAsLimitDuration: @NO,
+															  mAExportAsDuration: @30.0,
+															  mAExportAsExportWAV: @YES,
+															  mAExportAsExportOgg: @NO,
+															  mAExportAsExportM4A: @NO,
+															  mAExportAsExportMP3: @NO,
+															  }];
 }
 
 - (int)numSelectedFileTypes
 {
 	int selectedFileTypeCount =
-		(self.exportWAV ? 1 : 0) +
-		(self.exportOgg ? 1 : 0) +
-		(self.exportM4A ? 1 : 0) +
-		(self.exportMP3 ? 1 : 0);
+	(self.exportWAV ? 1 : 0) +
+	(self.exportOgg ? 1 : 0) +
+	(self.exportM4A ? 1 : 0) +
+	(self.exportMP3 ? 1 : 0);
 	
 	return selectedFileTypeCount;
 }
 
 - (CGFloat)duration
 {
-    duration = [_durationTextField doubleValue];
-    return duration;
+	duration = [_durationTextField doubleValue];
+	return duration;
 }
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
-    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
-    if (self)
-    {
-    }
-    
-    return self;
+	self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+	if (self)
+	{
+	}
+	
+	return self;
 }
 
 - (void)awakeFromNib
 {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    
-    self.limitDuration = [defaults boolForKey:mAExportAsLimitDuration];
-    self.duration = [defaults floatForKey:mAExportAsDuration];
-    
-    self.exportWAV = [defaults boolForKey:mAExportAsExportWAV];
-    self.exportOgg = [defaults boolForKey:mAExportAsExportOgg];
-    self.exportM4A = [defaults boolForKey:mAExportAsExportM4A];
-    self.exportMP3 = [defaults boolForKey:mAExportAsExportMP3];
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	
-    self.enableMP3 = g_lameAvailable;
+	self.limitDuration = [defaults boolForKey:mAExportAsLimitDuration];
+	self.duration = [defaults floatForKey:mAExportAsDuration];
+	
+	self.exportWAV = [defaults boolForKey:mAExportAsExportWAV];
+	self.exportOgg = [defaults boolForKey:mAExportAsExportOgg];
+	self.exportM4A = [defaults boolForKey:mAExportAsExportM4A];
+	self.exportMP3 = [defaults boolForKey:mAExportAsExportMP3];
+	
+	self.enableMP3 = g_lameAvailable;
 }
 
 /*
@@ -135,7 +135,7 @@ static BOOL g_lameAvailable = NO;
 	switch (self.numSelectedFileTypes) {
 		case 0:
 			[savePanel setAllowedFileTypes:@[@""]];
-
+			
 			if (exportButtonAvailable) {
 				savePanel.message = @"REQUIRED: one or more export types must be selected";
 				exportButton.enabled = false;
@@ -177,16 +177,16 @@ static BOOL g_lameAvailable = NO;
 	[savePanel setAllowedFileTypes:@[@"wav"]];
 	
 	if (self.numSelectedFileTypes == 0) {
-			self.exportWAV = YES;
+		self.exportWAV = YES;
 	}
 	
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setBool:self.limitDuration forKey:mAExportAsLimitDuration];
-    [defaults setFloat:self.duration forKey:mAExportAsDuration];
-    [defaults setBool:self.exportWAV forKey:mAExportAsExportWAV];
-    [defaults setBool:self.exportOgg forKey:mAExportAsExportOgg];
-    [defaults setBool:self.exportM4A forKey:mAExportAsExportM4A];
-    [defaults setBool:self.exportMP3 forKey:mAExportAsExportMP3];
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	[defaults setBool:self.limitDuration forKey:mAExportAsLimitDuration];
+	[defaults setFloat:self.duration forKey:mAExportAsDuration];
+	[defaults setBool:self.exportWAV forKey:mAExportAsExportWAV];
+	[defaults setBool:self.exportOgg forKey:mAExportAsExportOgg];
+	[defaults setBool:self.exportM4A forKey:mAExportAsExportM4A];
+	[defaults setBool:self.exportMP3 forKey:mAExportAsExportMP3];
 }
 
 @end

--- a/src/macosx/mAExportAsViewController.m
+++ b/src/macosx/mAExportAsViewController.m
@@ -70,6 +70,13 @@ static BOOL g_lameAvailable = NO;
 															  mAExportAsExportM4A: @NO,
 															  mAExportAsExportMP3: @NO,
 															  }];
+    
+    // unremark to set defaults for testing //
+//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportWAV];
+//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportOgg];
+//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportM4A];
+//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:mAExportAsExportMP3];
+    // end unremark to set defaults for testing //
 }
 
 - (int)numSelectedFileTypes

--- a/src/macosx/mAExportAsViewController.m
+++ b/src/macosx/mAExportAsViewController.m
@@ -133,10 +133,8 @@ static BOOL g_lameAvailable = NO;
 	BOOL exportButtonAvailable = (exportButton != nil);
 	
 	if (exportButtonAvailable && self.numSelectedFileTypes > 0) {
-		if (exportButtonAvailable) {
-			savePanel.message = @"";
-			exportButton.enabled = true;
-		}
+        savePanel.message = @"";
+        exportButton.enabled = YES;
 	}
 	
 	switch (self.numSelectedFileTypes) {
@@ -145,7 +143,7 @@ static BOOL g_lameAvailable = NO;
 			
 			if (exportButtonAvailable) {
 				savePanel.message = @"REQUIRED: one or more export types must be selected";
-				exportButton.enabled = false;
+				exportButton.enabled = NO;
 			}
 			break;
 			

--- a/src/macosx/mAExportAsViewController.m
+++ b/src/macosx/mAExportAsViewController.m
@@ -51,6 +51,7 @@ static BOOL g_lameAvailable = NO;
 @implementation mAExportAsViewController
 
 @synthesize savePanel;
+@synthesize exportButtonTag;
 @synthesize numSelectedFileTypes;
 
 @synthesize limitDuration, duration;
@@ -121,9 +122,24 @@ static BOOL g_lameAvailable = NO;
  */
 - (IBAction)formatButtonClick:(id)sender
 {
+	NSButton *exportButton = [savePanel.contentView viewWithTag: exportButtonTag];
+	BOOL exportButtonAvailable = (exportButton != nil);
+	
+	if (exportButtonAvailable && self.numSelectedFileTypes > 0) {
+		if (exportButtonAvailable) {
+			savePanel.message = @"";
+			exportButton.enabled = true;
+		}
+	}
+	
 	switch (self.numSelectedFileTypes) {
 		case 0:
-			[savePanel setAllowedFileTypes:@[@"<error>"]];
+			[savePanel setAllowedFileTypes:@[@""]];
+
+			if (exportButtonAvailable) {
+				savePanel.message = @"REQUIRED: one or more export types must be selected";
+				exportButton.enabled = false;
+			}
 			break;
 			
 		case 1:

--- a/src/macosx/miniAudicleDocument.mm
+++ b/src/macosx/miniAudicleDocument.mm
@@ -325,7 +325,7 @@
     int numFormatsSelected = viewController.numSelectedFileTypes;
     if (numFormatsSelected == 0) {
         [savePanel disableButtonWithTag:exportButtonTagValue];
-        savePanel.message = @"Please select a format for the export.";
+        savePanel.message = viewController.noSelectedFormatsMessage;
     }
 }
 

--- a/src/macosx/miniAudicleDocument.mm
+++ b/src/macosx/miniAudicleDocument.mm
@@ -273,11 +273,17 @@ U.S.A.
 
 - (IBAction)exportAsWAV:(id)sender
 {
+	// constants for changing the save panel's OK button title
+	// and setting a tag to access the button via -viewWithTag
+	NSString * panelOKButtonTitle = @"Export";
+	int exportButtonTagValue = 666;
+	
+	
     NSSavePanel * savePanel = [NSSavePanel savePanel];
     [savePanel setAllowedFileTypes:@[@"wav"]];
     [savePanel setTitle:@"Export as WAV"];
     [savePanel setNameFieldLabel:@"Export to:"];
-    [savePanel setPrompt:@"Export"];
+    [savePanel setPrompt:panelOKButtonTitle];
     
     NSString * filename;
     NSString * directory;
@@ -298,11 +304,37 @@ U.S.A.
     [savePanel setDirectory:directory];
     
     [savePanel setExtensionHidden:NO];
-    
-    mAExportAsViewController * viewController = [[mAExportAsViewController alloc] initWithNibName:@"mAExportAs" bundle:nil];
+	
+	// set tag on panel's "Export" button (panel -> subview -> sub-subview level)
+	NSArray *panelLevel1Views = savePanel.contentView.subviews;
+	BOOL canStopNow = false;
+	
+	for (NSView *level1View in panelLevel1Views) {
+		
+		NSArray *level2Views = level1View.subviews;
+		
+		for (NSView *level2View in level2Views) {
+			
+			if ([level2View isKindOfClass:NSButton.class]) {
+				
+				NSString *btnTitle = ((NSButton *)level2View).title;
+				
+				if ([btnTitle  isEqual: panelOKButtonTitle]) {
+					[(NSButton *)level2View setTag:exportButtonTagValue];
+					canStopNow = true;
+					break;
+				}
+			}
+		}
+		
+		if (canStopNow) { break; }
+	}
+	
+	mAExportAsViewController * viewController = [[mAExportAsViewController alloc] initWithNibName:@"mAExportAs" bundle:nil];
     [savePanel setAccessoryView:viewController.view];
 	viewController.savePanel = savePanel;
-
+	viewController.exportButtonTag = exportButtonTagValue;
+	
     [savePanel beginSheetForDirectory:directory
                                  file:filename
                        modalForWindow:[self.windowController window]

--- a/src/macosx/miniAudicleDocument.mm
+++ b/src/macosx/miniAudicleDocument.mm
@@ -301,6 +301,7 @@ U.S.A.
     
     mAExportAsViewController * viewController = [[mAExportAsViewController alloc] initWithNibName:@"mAExportAs" bundle:nil];
     [savePanel setAccessoryView:viewController.view];
+	viewController.savePanel = savePanel;
 
     [savePanel beginSheetForDirectory:directory
                                  file:filename

--- a/src/macosx/miniAudicleDocument.mm
+++ b/src/macosx/miniAudicleDocument.mm
@@ -1,26 +1,26 @@
 /*----------------------------------------------------------------------------
-miniAudicle
-Cocoa GUI to chuck audio programming environment
-
-Copyright (c) 2005-2013 Spencer Salazar.  All rights reserved.
-http://chuck.cs.princeton.edu/
-http://soundlab.cs.princeton.edu/
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-U.S.A.
------------------------------------------------------------------------------*/
+ miniAudicle
+ Cocoa GUI to chuck audio programming environment
+ 
+ Copyright (c) 2005-2013 Spencer Salazar.  All rights reserved.
+ http://chuck.cs.princeton.edu/
+ http://soundlab.cs.princeton.edu/
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+ U.S.A.
+ -----------------------------------------------------------------------------*/
 
 //-----------------------------------------------------------------------------
 // file: miniAudicleDocument.mm
@@ -73,24 +73,24 @@ U.S.A.
 
 - (id)init
 {
-    if( self = [super init] )
-    {
-        ma = nil;
-        
-        shows_arguments = YES;
-        shows_toolbar = YES;
-        shows_line_numbers = YES;
-        shows_status_bar = YES;
-        
-        has_customized_appearance = NO;
-        
-//        fsEventsWatcher = [UKFSEventsWatcher new];
-//        fsEventsWatcher.delegate = self;
-        
-        self.readOnly = NO;
-    }
-    
-    return self;
+	if( self = [super init] )
+	{
+		ma = nil;
+		
+		shows_arguments = YES;
+		shows_toolbar = YES;
+		shows_line_numbers = YES;
+		shows_status_bar = YES;
+		
+		has_customized_appearance = NO;
+		
+		//        fsEventsWatcher = [UKFSEventsWatcher new];
+		//        fsEventsWatcher.delegate = self;
+		
+		self.readOnly = NO;
+	}
+	
+	return self;
 }
 
 - (void)awakeFromNib
@@ -99,32 +99,32 @@ U.S.A.
 
 - (void)dealloc
 {
-    [data release];
-    data = nil;
-    
-    if( ma != nil )
-    {
-        ma->free_document_id( docid );
-        docid = 0;
-        ma = nil;
-    }
-    
-    _viewController.document = nil;
-    [_viewController release];
-    _viewController = nil;
-    
-//    [fsEventsWatcher release];
-    
-    [super dealloc];
+	[data release];
+	data = nil;
+	
+	if( ma != nil )
+	{
+		ma->free_document_id( docid );
+		docid = 0;
+		ma = nil;
+	}
+	
+	_viewController.document = nil;
+	[_viewController release];
+	_viewController = nil;
+	
+	//    [fsEventsWatcher release];
+	
+	[super dealloc];
 }
 
 - (void)makeWindowControllers
 {
-    miniAudicleController * mac = [NSDocumentController sharedDocumentController];
-    mAMultiDocWindowController *_wc = [mac windowControllerForNewDocument];
-    [_wc addDocument:self];
-    [[_wc window] makeKeyAndOrderFront:self];
-//    self.windowController = [mac topWindowController];
+	miniAudicleController * mac = [NSDocumentController sharedDocumentController];
+	mAMultiDocWindowController *_wc = [mac windowControllerForNewDocument];
+	[_wc addDocument:self];
+	[[_wc window] makeKeyAndOrderFront:self];
+	//    self.windowController = [mac topWindowController];
 }
 
 //- (NSArray *)windowControllers
@@ -137,114 +137,114 @@ U.S.A.
 //
 - (NSString *)windowNibName
 {
-    assert(false);
-    // Override returning the nib file name of the document
-    // If you need to use a subclass of NSWindowController or if your document supports multiple NSWindowControllers, you should remove this method and override -makeWindowControllers instead.
-    return @"";
+	assert(false);
+	// Override returning the nib file name of the document
+	// If you need to use a subclass of NSWindowController or if your document supports multiple NSWindowControllers, you should remove this method and override -makeWindowControllers instead.
+	return @"";
 }
 
 -(NSViewController *)newPrimaryViewController
 {
-    mADocumentViewController* ctrl = [[mADocumentViewController alloc] initWithNibName:@"mADocumentView" bundle:nil];
-    ctrl.document = self;
-    [ctrl setMiniAudicle:ma];
-    _viewController = ctrl;
-    
-    return ctrl;
+	mADocumentViewController* ctrl = [[mADocumentViewController alloc] initWithNibName:@"mADocumentView" bundle:nil];
+	ctrl.document = self;
+	[ctrl setMiniAudicle:ma];
+	_viewController = ctrl;
+	
+	return ctrl;
 }
 
 - (void)saveDocument:(id)sender
 {
-    if(self.readOnly)
-    {
-        NSAlert * alert = [NSAlert alertWithMessageText:[NSString stringWithFormat:@"The document '%@' is read-only.",
-                                                         [self displayName]]
-                                          defaultButton:@"Save As..."
-                                        alternateButton:@"Cancel"
-                                            otherButton:nil
-                              informativeTextWithFormat:@"Click Save As to save the document to a different file. Click Cancel to cancel the save operation."];
-        
-        [alert beginSheetModalForWindow:[_windowController window]
-                          modalDelegate:self
-                         didEndSelector:@selector(documentIsReadOnlyAlertEnded:returnCode:contextInfo:)
-                            contextInfo:nil];
-    }
-    else
-    {
-        [super saveDocument:sender];
-    }
+	if(self.readOnly)
+	{
+		NSAlert * alert = [NSAlert alertWithMessageText:[NSString stringWithFormat:@"The document '%@' is read-only.",
+														 [self displayName]]
+										  defaultButton:@"Save As..."
+										alternateButton:@"Cancel"
+											otherButton:nil
+							  informativeTextWithFormat:@"Click Save As to save the document to a different file. Click Cancel to cancel the save operation."];
+		
+		[alert beginSheetModalForWindow:[_windowController window]
+						  modalDelegate:self
+						 didEndSelector:@selector(documentIsReadOnlyAlertEnded:returnCode:contextInfo:)
+							contextInfo:nil];
+	}
+	else
+	{
+		[super saveDocument:sender];
+	}
 }
 
 - (void)documentIsReadOnlyAlertEnded:(NSAlert *)alert
-                          returnCode:(NSInteger)returnCode
-                         contextInfo:(void *)contextInfo
+						  returnCode:(NSInteger)returnCode
+						 contextInfo:(void *)contextInfo
 {
-    if(returnCode == NSAlertDefaultReturn)
-    {
-        [[alert window] close];
-        
-        [self saveDocumentAs:self];
-    }
-    else if(returnCode == NSAlertAlternateReturn)
-    {
-    }
+	if(returnCode == NSAlertDefaultReturn)
+	{
+		[[alert window] close];
+		
+		[self saveDocumentAs:self];
+	}
+	else if(returnCode == NSAlertAlternateReturn)
+	{
+	}
 }
 
 - (BOOL)prepareSavePanel:(NSSavePanel *)savePanel
 {
-    BOOL r = [super prepareSavePanel:savePanel];
-    
-    if(self.readOnly)
-        savePanel.directory = NSHomeDirectory();
-    
-    return r;
+	BOOL r = [super prepareSavePanel:savePanel];
+	
+	if(self.readOnly)
+		savePanel.directory = NSHomeDirectory();
+	
+	return r;
 }
 
 - (NSData *)dataRepresentationOfType:(NSString *)type
 {
-    return [[_viewController content] dataUsingEncoding:NSUTF8StringEncoding
-                                   allowLossyConversion:YES];
+	return [[_viewController content] dataUsingEncoding:NSUTF8StringEncoding
+								   allowLossyConversion:YES];
 }
 
 - (BOOL)loadDataRepresentation:(NSData *)_data ofType:(NSString *)type
 {
-    data = [[NSString alloc] initWithData:_data encoding:NSUTF8StringEncoding];
-    [_viewController setContent:data];
-    
-    return YES;
+	data = [[NSString alloc] initWithData:_data encoding:NSUTF8StringEncoding];
+	[_viewController setContent:data];
+	
+	return YES;
 }
 
 - (void)setFileURL:(NSURL *)url
 {
-    [super setFileURL:url];
-    
-    self.readOnly = [url isEnclosedByDirectory:[[NSBundle mainBundle] resourceURL]];
-        
-//    [fsEventsWatcher removeAllPaths];
-//    [fsEventsWatcher addPath:[url path]];
+	[super setFileURL:url];
+	
+	self.readOnly = [url isEnclosedByDirectory:[[NSBundle mainBundle] resourceURL]];
+	
+	//    [fsEventsWatcher removeAllPaths];
+	//    [fsEventsWatcher addPath:[url path]];
 }
 
 - (BOOL)isEmpty
 {
-    return [self.viewController isEmpty] && ![self isDocumentEdited] && [self fileURL] == nil;
+	return [self.viewController isEmpty] && ![self isDocumentEdited] && [self fileURL] == nil;
 }
 
 /* override to set edited/unedited state in window/view controllers */
 - (void)updateChangeCount:(NSDocumentChangeType)changeType
 {
-    [super updateChangeCount:changeType];
-    
-    if(changeType == NSChangeCleared)
-    {
-        _viewController.isEdited = NO;
-        [_windowController document:self wasEdited:NO];
-        [_windowController updateTitles];
-    }
-    else
-    {
-        _viewController.isEdited = YES;
-        [_windowController document:self wasEdited:YES];
-    }
+	[super updateChangeCount:changeType];
+	
+	if(changeType == NSChangeCleared)
+	{
+		_viewController.isEdited = NO;
+		[_windowController document:self wasEdited:NO];
+		[_windowController updateTitles];
+	}
+	else
+	{
+		_viewController.isEdited = YES;
+		[_windowController document:self wasEdited:YES];
+	}
 }
 
 ///* override to avoid spurious "save changes?" panel when closing the window */
@@ -258,14 +258,14 @@ U.S.A.
 
 - (NSWindow * )windowForSheet
 {
-    return _windowController.window;
+	return _windowController.window;
 }
 
 
 - (void)setMiniAudicle:(miniAudicle *)t_ma
 {
-    ma = t_ma;
-    docid = ma->allocate_document_id();
+	ma = t_ma;
+	docid = ma->allocate_document_id();
 }
 
 
@@ -279,31 +279,31 @@ U.S.A.
 	int exportButtonTagValue = 666;
 	
 	
-    NSSavePanel * savePanel = [NSSavePanel savePanel];
-    [savePanel setAllowedFileTypes:@[@"wav"]];
-    [savePanel setTitle:@"Export as WAV"];
-    [savePanel setNameFieldLabel:@"Export to:"];
-    [savePanel setPrompt:panelOKButtonTitle];
-    
-    NSString * filename;
-    NSString * directory;
-    
-    if([self fileURL] != nil)
-    {
-        filename = [[[[[self fileURL] path] lastPathComponent] stringByDeletingPathExtension] stringByAppendingPathExtension:@"wav"];
-        directory = [[[self fileURL] path] stringByDeletingLastPathComponent];
-    }
-    else
-    {
-        filename = [[self displayName] stringByAppendingPathExtension:@"wav"];
-        directory = [[NSDocumentController sharedDocumentController] currentDirectory];
-    }
-    
-    if([savePanel respondsToSelector:@selector(setNameFieldStringValue:)])
-        [savePanel setNameFieldStringValue:filename];
-    [savePanel setDirectory:directory];
-    
-    [savePanel setExtensionHidden:NO];
+	NSSavePanel * savePanel = [NSSavePanel savePanel];
+	[savePanel setAllowedFileTypes:@[@"wav"]];
+	[savePanel setTitle:@"Export as WAV"];
+	[savePanel setNameFieldLabel:@"Export to:"];
+	[savePanel setPrompt:panelOKButtonTitle];
+	
+	NSString * filename;
+	NSString * directory;
+	
+	if([self fileURL] != nil)
+	{
+		filename = [[[[[self fileURL] path] lastPathComponent] stringByDeletingPathExtension] stringByAppendingPathExtension:@"wav"];
+		directory = [[[self fileURL] path] stringByDeletingLastPathComponent];
+	}
+	else
+	{
+		filename = [[self displayName] stringByAppendingPathExtension:@"wav"];
+		directory = [[NSDocumentController sharedDocumentController] currentDirectory];
+	}
+	
+	if([savePanel respondsToSelector:@selector(setNameFieldStringValue:)])
+		[savePanel setNameFieldStringValue:filename];
+	[savePanel setDirectory:directory];
+	
+	[savePanel setExtensionHidden:NO];
 	
 	// set tag on panel's "Export" button (panel -> subview -> sub-subview level)
 	NSArray *panelLevel1Views = savePanel.contentView.subviews;
@@ -331,45 +331,45 @@ U.S.A.
 	}
 	
 	mAExportAsViewController * viewController = [[mAExportAsViewController alloc] initWithNibName:@"mAExportAs" bundle:nil];
-    [savePanel setAccessoryView:viewController.view];
+	[savePanel setAccessoryView:viewController.view];
 	viewController.savePanel = savePanel;
 	viewController.exportButtonTag = exportButtonTagValue;
 	
-    [savePanel beginSheetForDirectory:directory
-                                 file:filename
-                       modalForWindow:[self.windowController window]
-                        modalDelegate:self
-                       didEndSelector:@selector(savePanelDidEnd:returnCode:contextInfo:)
-                          contextInfo:viewController];
+	[savePanel beginSheetForDirectory:directory
+								 file:filename
+					   modalForWindow:[self.windowController window]
+						modalDelegate:self
+					   didEndSelector:@selector(savePanelDidEnd:returnCode:contextInfo:)
+						  contextInfo:viewController];
 }
 
 - (void)savePanelDidEnd:(NSSavePanel *)sheet
-             returnCode:(int)returnCode
-            contextInfo:(void *)contextInfo;
+			 returnCode:(int)returnCode
+			contextInfo:(void *)contextInfo;
 {
-    [sheet orderOut:self];
-    
-    mAExportAsViewController * viewController = (mAExportAsViewController *) contextInfo;
-    NSSavePanel * savePanel = (NSSavePanel *) sheet;
-    
-    if(returnCode == NSOKButton)
-    {
-        [viewController saveSettings];
-        
-        self.exporter = [[mADocumentExporter alloc] initWithDocument:self
-                                                     destinationPath:[[savePanel URL] path]];
-        
-        self.exporter.limitDuration = viewController.limitDuration;
-        self.exporter.duration = viewController.duration;
-        self.exporter.exportWAV = viewController.exportWAV;
-        self.exporter.exportOgg = viewController.exportOgg;
-        self.exporter.exportM4A = viewController.exportM4A;
-        self.exporter.exportMP3 = viewController.exportMP3;
-        
-        [self.exporter startExportWithDelegate:self];
-    }
-    
-    [viewController release];
+	[sheet orderOut:self];
+	
+	mAExportAsViewController * viewController = (mAExportAsViewController *) contextInfo;
+	NSSavePanel * savePanel = (NSSavePanel *) sheet;
+	
+	if(returnCode == NSOKButton)
+	{
+		[viewController saveSettings];
+		
+		self.exporter = [[mADocumentExporter alloc] initWithDocument:self
+													 destinationPath:[[savePanel URL] path]];
+		
+		self.exporter.limitDuration = viewController.limitDuration;
+		self.exporter.duration = viewController.duration;
+		self.exporter.exportWAV = viewController.exportWAV;
+		self.exporter.exportOgg = viewController.exportOgg;
+		self.exporter.exportM4A = viewController.exportM4A;
+		self.exporter.exportMP3 = viewController.exportMP3;
+		
+		[self.exporter startExportWithDelegate:self];
+	}
+	
+	[viewController release];
 }
 
 
@@ -377,46 +377,46 @@ U.S.A.
 
 - (void)watcher:(id<UKFileWatcher>)kq receivedNotification:(NSString*)nm forPath:(NSString*)fpath
 {
-//    if([nm isEqualToString:UKFileWatcherWriteNotification])
-//    {
-//        if([self isDocumentEdited])
-//        {
-//            NSAlert *alert = [NSAlert alertWithMessageText:[NSString stringWithFormat:@"The document \"%@\" has been changed by another application.",
-//                                                            [self displayName]]
-//                                             defaultButton:@"Save Anyway"
-//                                           alternateButton:@"Revert"
-//                                               otherButton:@""
-//                                 informativeTextWithFormat:@"Click Save Anyway to overwrite these changes and save your changes. Click Revert to discard your changes and keep the changes from the other appliction."];
-//            [alert beginSheetModalForWindow:[_windowController window]
-//                              modalDelegate:self
-//                             didEndSelector:@selector(documentChangedByAnotherApplictionAlertDidEnd:returnCode:contextInfo:)
-//                                contextInfo:nil];
-//        }
-//        else
-//        {
-//            NSError *error;
-//            if(![self revertToContentsOfURL:[self fileURL] ofType:[self fileType] error:&error])
-//                [[NSAlert alertWithError:error] beginSheetModalForWindow:[_windowController window] modalDelegate:nil didEndSelector:nil contextInfo:nil];
-//        }
-//    }
+	//    if([nm isEqualToString:UKFileWatcherWriteNotification])
+	//    {
+	//        if([self isDocumentEdited])
+	//        {
+	//            NSAlert *alert = [NSAlert alertWithMessageText:[NSString stringWithFormat:@"The document \"%@\" has been changed by another application.",
+	//                                                            [self displayName]]
+	//                                             defaultButton:@"Save Anyway"
+	//                                           alternateButton:@"Revert"
+	//                                               otherButton:@""
+	//                                 informativeTextWithFormat:@"Click Save Anyway to overwrite these changes and save your changes. Click Revert to discard your changes and keep the changes from the other appliction."];
+	//            [alert beginSheetModalForWindow:[_windowController window]
+	//                              modalDelegate:self
+	//                             didEndSelector:@selector(documentChangedByAnotherApplictionAlertDidEnd:returnCode:contextInfo:)
+	//                                contextInfo:nil];
+	//        }
+	//        else
+	//        {
+	//            NSError *error;
+	//            if(![self revertToContentsOfURL:[self fileURL] ofType:[self fileType] error:&error])
+	//                [[NSAlert alertWithError:error] beginSheetModalForWindow:[_windowController window] modalDelegate:nil didEndSelector:nil contextInfo:nil];
+	//        }
+	//    }
 }
 
 - (void)documentChangedByAnotherApplictionAlertDidEnd:(NSAlert *)alert
-                                           returnCode:(NSInteger)returnCode
-                                          contextInfo:(void *)contextInfo
+										   returnCode:(NSInteger)returnCode
+										  contextInfo:(void *)contextInfo
 {
-    if(returnCode == NSAlertDefaultReturn)
-    {
-        NSError *error;
-        if(![self saveToURL:[self fileURL] ofType:[self fileType] forSaveOperation:NSSaveOperation error:&error])
-            [[NSAlert alertWithError:error] beginSheetModalForWindow:[_windowController window] modalDelegate:nil didEndSelector:nil contextInfo:nil];
-    }
-    else if(returnCode == NSAlertAlternateReturn)
-    {
-        NSError *error;
-        if(![self revertToContentsOfURL:[self fileURL] ofType:[self fileType] error:&error])
-            [[NSAlert alertWithError:error] beginSheetModalForWindow:[_windowController window] modalDelegate:nil didEndSelector:nil contextInfo:nil];
-    }
+	if(returnCode == NSAlertDefaultReturn)
+	{
+		NSError *error;
+		if(![self saveToURL:[self fileURL] ofType:[self fileType] forSaveOperation:NSSaveOperation error:&error])
+			[[NSAlert alertWithError:error] beginSheetModalForWindow:[_windowController window] modalDelegate:nil didEndSelector:nil contextInfo:nil];
+	}
+	else if(returnCode == NSAlertAlternateReturn)
+	{
+		NSError *error;
+		if(![self revertToContentsOfURL:[self fileURL] ofType:[self fileType] error:&error])
+			[[NSAlert alertWithError:error] beginSheetModalForWindow:[_windowController window] modalDelegate:nil didEndSelector:nil contextInfo:nil];
+	}
 }
 
 
@@ -428,25 +428,25 @@ U.S.A.
 
 - (BOOL)isEnclosedByDirectory:(NSURL *)dirPath
 {
-    NSURL * filePath = [self standardizedURL];
-    dirPath = [dirPath standardizedURL];
-    
-    NSArray * fileComponents = [filePath pathComponents];
-    NSArray * dirComponents = [dirPath pathComponents];
-    
-    for(int i = 0; i < [dirComponents count]; i++)
-    {
-        if(i >= [fileComponents count])
-            return NO;
-        
-        NSString *fileComponent = [fileComponents objectAtIndex:i];
-        NSString *dirComponent = [dirComponents objectAtIndex:i];
-        
-        if([fileComponent compare:dirComponent options:NSCaseInsensitiveSearch] != NSOrderedSame)
-            return NO;
-    }
-    
-    return YES;
+	NSURL * filePath = [self standardizedURL];
+	dirPath = [dirPath standardizedURL];
+	
+	NSArray * fileComponents = [filePath pathComponents];
+	NSArray * dirComponents = [dirPath pathComponents];
+	
+	for(int i = 0; i < [dirComponents count]; i++)
+	{
+		if(i >= [fileComponents count])
+			return NO;
+		
+		NSString *fileComponent = [fileComponents objectAtIndex:i];
+		NSString *dirComponent = [dirComponents objectAtIndex:i];
+		
+		if([fileComponent compare:dirComponent options:NSCaseInsensitiveSearch] != NSOrderedSame)
+			return NO;
+	}
+	
+	return YES;
 }
 
 @end

--- a/src/macosx/miniAudicleDocument.mm
+++ b/src/macosx/miniAudicleDocument.mm
@@ -314,13 +314,19 @@
 	[savePanel setAccessoryView:viewController.view];
 	viewController.savePanel = savePanel;
 	viewController.exportButtonTag = exportButtonTagValue;
-	
+    
 	[savePanel beginSheetForDirectory:directory
 								 file:filename
 					   modalForWindow:[self.windowController window]
 						modalDelegate:self
 					   didEndSelector:@selector(savePanelDidEnd:returnCode:contextInfo:)
 						  contextInfo:viewController];
+    
+    int numFormatsSelected = viewController.numSelectedFileTypes;
+    if (numFormatsSelected == 0) {
+        [savePanel disableButtonWithTag:exportButtonTagValue];
+        savePanel.message = @"Please select a format for the export.";
+    }
 }
 
 - (void)savePanelDidEnd:(NSSavePanel *)sheet

--- a/src/macosx/miniAudicleDocument.mm
+++ b/src/macosx/miniAudicleDocument.mm
@@ -59,6 +59,8 @@
 
 @property (nonatomic, strong) mADocumentExporter * exporter;
 
+- (void)setTag:(int)tagValue forButtonWithTitle:(NSString *)title onPanel:(NSPanel *)panel;
+
 @end
 
 
@@ -284,6 +286,8 @@
 	[savePanel setTitle:@"Export as WAV"];
 	[savePanel setNameFieldLabel:@"Export to:"];
 	[savePanel setPrompt:panelOKButtonTitle];
+    
+    [self setTag:exportButtonTagValue forButtonWithTitle:panelOKButtonTitle onPanel:(NSPanel *)savePanel];
 	
 	NSString * filename;
 	NSString * directory;
@@ -304,32 +308,7 @@
 	[savePanel setDirectory:directory];
 	
 	[savePanel setExtensionHidden:NO];
-	
-	// set tag on panel's "Export" button (panel -> subview -> sub-subview level)
-	NSArray *panelLevel1Views = savePanel.contentView.subviews;
-	BOOL canStopNow = false;
-	
-	for (NSView *level1View in panelLevel1Views) {
-		
-		NSArray *level2Views = level1View.subviews;
-		
-		for (NSView *level2View in level2Views) {
-			
-			if ([level2View isKindOfClass:NSButton.class]) {
-				
-				NSString *btnTitle = ((NSButton *)level2View).title;
-				
-				if ([btnTitle  isEqual: panelOKButtonTitle]) {
-					[(NSButton *)level2View setTag:exportButtonTagValue];
-					canStopNow = true;
-					break;
-				}
-			}
-		}
-		
-		if (canStopNow) { break; }
-	}
-	
+    
 	mAExportAsViewController * viewController = [[mAExportAsViewController alloc] initWithNibName:@"mAExportAs" bundle:nil];
 	[savePanel setAccessoryView:viewController.view];
 	viewController.savePanel = savePanel;
@@ -419,7 +398,33 @@
 	}
 }
 
-
+- (void)setTag:(int)tagValue forButtonWithTitle:(NSString *)title onPanel:(NSPanel *)panel
+{
+    // set tag on panel's "Export" button (panel -> subview -> sub-subview level)
+    NSArray *panelLevel1Views = panel.contentView.subviews;
+    BOOL canStopNow = false;
+    
+    for (NSView *level1View in panelLevel1Views) {
+        
+        NSArray *level2Views = level1View.subviews;
+        
+        for (NSView *level2View in level2Views) {
+            
+            if ([level2View isKindOfClass:NSButton.class]) {
+                
+                NSString *btnTitle = ((NSButton *)level2View).title;
+                
+                if ([btnTitle  isEqual: title]) {
+                    [(NSButton *)level2View setTag:tagValue];
+                    canStopNow = true;
+                    break;
+                }
+            }
+        }
+        
+        if (canStopNow) { break; }
+    }
+}
 
 @end
 

--- a/src/macosx/miniAudicleDocument.mm
+++ b/src/macosx/miniAudicleDocument.mm
@@ -311,22 +311,19 @@
 	[savePanel setExtensionHidden:NO];
     
 	mAExportAsViewController * viewController = [[mAExportAsViewController alloc] initWithNibName:@"mAExportAs" bundle:nil];
-	[savePanel setAccessoryView:viewController.view];
 	viewController.savePanel = savePanel;
 	viewController.exportButtonTag = exportButtonTagValue;
-    
+
+	[savePanel setAccessoryView:viewController.view];
+	
 	[savePanel beginSheetForDirectory:directory
 								 file:filename
 					   modalForWindow:[self.windowController window]
 						modalDelegate:self
 					   didEndSelector:@selector(savePanelDidEnd:returnCode:contextInfo:)
 						  contextInfo:viewController];
-    
-    int numFormatsSelected = viewController.numSelectedFileTypes;
-    if (numFormatsSelected == 0) {
-        [savePanel disableButtonWithTag:exportButtonTagValue];
-        savePanel.message = viewController.noSelectedFormatsMessage;
-    }
+	
+	[viewController configureSavePanelForSelectedFormats];
 }
 
 - (void)savePanelDidEnd:(NSSavePanel *)sheet

--- a/src/macosx/miniAudicleDocument.mm
+++ b/src/macosx/miniAudicleDocument.mm
@@ -43,6 +43,7 @@
 #import "mAMultiDocWindowController.h"
 #import "UKFSEventsWatcher.h"
 #import "mAExportAsViewController.h"
+#import "NSPanel+ButtonTag.h"
 
 #import <objc/message.h>
 
@@ -59,7 +60,7 @@
 
 @property (nonatomic, strong) mADocumentExporter * exporter;
 
-- (void)setTag:(int)tagValue forButtonWithTitle:(NSString *)title onPanel:(NSPanel *)panel;
+//- (void)setTag:(int)tagValue forButtonWithTitle:(NSString *)title onPanel:(NSPanel *)panel;
 
 @end
 
@@ -287,7 +288,7 @@
 	[savePanel setNameFieldLabel:@"Export to:"];
 	[savePanel setPrompt:panelOKButtonTitle];
     
-    [self setTag:exportButtonTagValue forButtonWithTitle:panelOKButtonTitle onPanel:(NSPanel *)savePanel];
+    [savePanel setTag:exportButtonTagValue forButtonWithTitle:panelOKButtonTitle];
 	
 	NSString * filename;
 	NSString * directory;
@@ -396,34 +397,6 @@
 		if(![self revertToContentsOfURL:[self fileURL] ofType:[self fileType] error:&error])
 			[[NSAlert alertWithError:error] beginSheetModalForWindow:[_windowController window] modalDelegate:nil didEndSelector:nil contextInfo:nil];
 	}
-}
-
-- (void)setTag:(int)tagValue forButtonWithTitle:(NSString *)title onPanel:(NSPanel *)panel
-{
-    // set tag on panel's "Export" button (panel -> subview -> sub-subview level)
-    NSArray *panelLevel1Views = panel.contentView.subviews;
-    BOOL canStopNow = false;
-    
-    for (NSView *level1View in panelLevel1Views) {
-        
-        NSArray *level2Views = level1View.subviews;
-        
-        for (NSView *level2View in level2Views) {
-            
-            if ([level2View isKindOfClass:NSButton.class]) {
-                
-                NSString *btnTitle = ((NSButton *)level2View).title;
-                
-                if ([btnTitle  isEqual: title]) {
-                    [(NSButton *)level2View setTag:tagValue];
-                    canStopNow = true;
-                    break;
-                }
-            }
-        }
-        
-        if (canStopNow) { break; }
-    }
 }
 
 @end

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -155,7 +155,8 @@ OBJCSRCS+= $(OSX_DIR)/main.m \
     $(OSX_DIR)/UliKit/UKFileWatcher.m \
     $(OSX_DIR)/UliKit/UKFSEventsWatcher.m \
     $(OSX_DIR)/mAExportAsViewController.m \
-    $(OSX_DIR)/mAExportProgressViewController.m
+    $(OSX_DIR)/mAExportProgressViewController.m \
+    $(OSX_DIR)/NSPanel+ButtonTag.m
 OBJCXXSRCS+= $(OSX_DIR)/miniAudicleController.mm \
 	$(OSX_DIR)/miniAudicleVMMonitor.mm \
 	$(OSX_DIR)/miniAudicleDocument.mm \
@@ -174,7 +175,7 @@ OBJCXXSRCS+= $(OSX_DIR)/miniAudicleController.mm \
     $(OSX_DIR)/mARecordSessionController.mm \
     $(OSX_DIR)/NSString+STLString.mm \
     $(OSX_DIR)/mAExampleBrowser.mm \
-    $(OSX_DIR)/mADocumentExporter.mm
+    $(OSX_DIR)/mADocumentExporter.mm 
 
 
 COBJS=$(CSRCS:.c=.o)

--- a/src/miniAudicle.xcodeproj/project.pbxproj
+++ b/src/miniAudicle.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 		4D3D4C981A5E3A4400B6A06B /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D3D4C971A5E3A4400B6A06B /* SystemConfiguration.framework */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		D5A682F81E26B81D009A460F /* NSPanel+ButtonTag.m in Sources */ = {isa = PBXBuildFile; fileRef = D5A682F51E26A130009A460F /* NSPanel+ButtonTag.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -683,7 +684,7 @@
 		09A40BB00A9A55EC007604EA /* miniAudicleController.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = miniAudicleController.h; path = macosx/miniAudicleController.h; sourceTree = SOURCE_ROOT; };
 		09A40BB10A9A55EC007604EA /* miniAudicleController.mm */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.objcpp; name = miniAudicleController.mm; path = macosx/miniAudicleController.mm; sourceTree = SOURCE_ROOT; };
 		09A40BB20A9A55EC007604EA /* miniAudicleDocument.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = miniAudicleDocument.h; path = macosx/miniAudicleDocument.h; sourceTree = SOURCE_ROOT; };
-		09A40BB30A9A55EC007604EA /* miniAudicleDocument.mm */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.objcpp; name = miniAudicleDocument.mm; path = macosx/miniAudicleDocument.mm; sourceTree = SOURCE_ROOT; };
+		09A40BB30A9A55EC007604EA /* miniAudicleDocument.mm */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.objcpp; name = miniAudicleDocument.mm; path = macosx/miniAudicleDocument.mm; sourceTree = SOURCE_ROOT; usesTabs = 0; };
 		09A40BB40A9A55EC007604EA /* miniAudiclePreferencesController.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = miniAudiclePreferencesController.h; path = macosx/miniAudiclePreferencesController.h; sourceTree = SOURCE_ROOT; };
 		09A40BB50A9A55EC007604EA /* miniAudiclePreferencesController.mm */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.objcpp; name = miniAudiclePreferencesController.mm; path = macosx/miniAudiclePreferencesController.mm; sourceTree = SOURCE_ROOT; };
 		09A40BB60A9A55EC007604EA /* miniAudicleShellController.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = miniAudicleShellController.h; path = macosx/miniAudicleShellController.h; sourceTree = SOURCE_ROOT; };
@@ -763,8 +764,8 @@
 		09B596C219B066900091D45F /* mATextCompletionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mATextCompletionView.h; sourceTree = "<group>"; };
 		09B596C319B066900091D45F /* mATextCompletionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = mATextCompletionView.m; sourceTree = "<group>"; };
 		09B66B4A17683C7300A07ADF /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = macosx/Resources/English.lproj/mAExportAs.xib; sourceTree = "<group>"; };
-		09B66B4C1768460C00A07ADF /* mAExportAsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mAExportAsViewController.h; path = macosx/mAExportAsViewController.h; sourceTree = "<group>"; };
-		09B66B4D1768460C00A07ADF /* mAExportAsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = mAExportAsViewController.m; path = macosx/mAExportAsViewController.m; sourceTree = "<group>"; };
+		09B66B4C1768460C00A07ADF /* mAExportAsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mAExportAsViewController.h; path = macosx/mAExportAsViewController.h; sourceTree = "<group>"; usesTabs = 0; };
+		09B66B4D1768460C00A07ADF /* mAExportAsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = mAExportAsViewController.m; path = macosx/mAExportAsViewController.m; sourceTree = "<group>"; usesTabs = 0; };
 		09B66B4F1768A1E400A07ADF /* export.ck */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = export.ck; sourceTree = "<group>"; };
 		09B66B521768AC6000A07ADF /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = macosx/Resources/English.lproj/mAExportProgress.xib; sourceTree = "<group>"; };
 		09B66B541768AD5C00A07ADF /* mAExportProgressViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mAExportProgressViewController.h; path = macosx/mAExportProgressViewController.h; sourceTree = "<group>"; };
@@ -828,6 +829,8 @@
 		4D3D4C941A5E392800B6A06B /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		4D3D4C971A5E3A4400B6A06B /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
 		8D1107320486CEB800E47090 /* miniAudicle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = miniAudicle.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D5A682F51E26A130009A460F /* NSPanel+ButtonTag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSPanel+ButtonTag.m"; path = "macosx/NSPanel+ButtonTag.m"; sourceTree = "<group>"; usesTabs = 0; };
+		D5A682F71E26A192009A460F /* NSPanel+ButtonTag.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NSPanel+ButtonTag.h"; path = "macosx/NSPanel+ButtonTag.h"; sourceTree = "<group>"; usesTabs = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -923,6 +926,8 @@
 				0964A394172F8FD800043ABA /* mARecordSessionController.mm */,
 				0962903117323065007CADBA /* NSString+STLString.h */,
 				0962903217323065007CADBA /* NSString+STLString.mm */,
+				D5A682F71E26A192009A460F /* NSPanel+ButtonTag.h */,
+				D5A682F51E26A130009A460F /* NSPanel+ButtonTag.m */,
 				09B66B4C1768460C00A07ADF /* mAExportAsViewController.h */,
 				09B66B4D1768460C00A07ADF /* mAExportAsViewController.m */,
 				09B66B541768AD5C00A07ADF /* mAExportProgressViewController.h */,
@@ -2043,6 +2048,7 @@
 				09A40BC70A9A55EC007604EA /* NumberedTextView.mm in Sources */,
 				09A40BD00A9A5662007604EA /* miniAudicle_import.cpp in Sources */,
 				09A40BD10A9A5662007604EA /* miniAudicle_shell.cpp in Sources */,
+				D5A682F81E26B81D009A460F /* NSPanel+ButtonTag.m in Sources */,
 				09A40BD20A9A5662007604EA /* miniAudicle_ui_elements.cpp in Sources */,
 				09A40BD30A9A5662007604EA /* miniAudicle.cpp in Sources */,
 				09A40D130A9A6185007604EA /* chuck.lex in Sources */,


### PR DESCRIPTION
Added `IBAction` for the `mAExportAs.xib` buttons. When clicked, the extension on the `savePanel` filename is changed as follows:

- No format selections: `.<error>`
- More than one format selection: `.*`
- One format selection: the appropriate extension for the selection (`.wav`, `.ogg`, `.m4a`, `.mp3`)

`mADocumentExporter` is using the `exportAs...` values, rather than the actual filename extension, to determine the export file extension. Therefore, upon saving, the filename extension is changed back to `.wav` (as expected by `mADocumentExporter`).

Also upon saving, if no other formats have been selected, `exportAsWAV` is set to `YES`. If other formats have been selected, this is left as is.  Again, this is because `mADocumentExporter` is using the `exportAs...` values, rather than the actual filename extension, to determine the export file extension.

Added property for `mAExportAsViewController` connection to `miniAudicleDocument` `savePanel` so can retrieve the save panel's `setAllowedFileTypes` method.