### PR TITLE
Update to QT5

### DIFF
--- a/notes/README.linux
+++ b/notes/README.linux
@@ -31,8 +31,8 @@ bison
 flex
 libasound2-dev
 libsndfile1-dev
-libqt4-dev
-libqscintilla2-dev
+qtbase5-dev
+libqscintilla2-qt5-dev
 libpulse-dev (linux-pulse only)
 libjack-jackd2-dev (linux-jack only)
 
@@ -40,7 +40,7 @@ On systems with apt-get available, running the following command with the full
 list of packages will ensure that all necessary packages are installed.
 
 $ sudo apt-get install make gcc g++ bison flex libasound2-dev libsndfile1-dev \
-    libqt4-dev libqscintilla2-dev [libpulse-dev] [libjack-jackd2-dev]
+    qtbase5-dev libqscintilla2-qt5-dev [libpulse-dev] [libjack-jackd2-dev]
 
 
 Tips

--- a/src/makefile
+++ b/src/makefile
@@ -5,8 +5,8 @@ PREFIX=/usr
 
 CHUCK_SRC_DIR=chuck/src
 
-ifneq ($(shell which qmake-qt4),)
-QMAKE?=qmake-qt4
+ifneq ($(shell which qmake-qt5),)
+QMAKE?=qmake-qt5
 else
 QMAKE?=qmake
 endif

--- a/src/miniAudicle.pro
+++ b/src/miniAudicle.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui network
+QT       += core widgets gui network
 
 CONFIG += warn_off
 
@@ -23,7 +23,7 @@ OBJECTS_DIR = build
 
 PRECOMPILED_HEADER = qt/miniAudicle_pc.h
 
-LIBS += -lqscintilla2
+CONFIG += qscintilla2
 
 DEFINES += HAVE_CONFIG_H
 

--- a/src/qt/mAVMMonitor.cpp
+++ b/src/qt/mAVMMonitor.cpp
@@ -64,7 +64,7 @@ mAVMMonitor::mAVMMonitor(QWidget *parent, mAMainWindow *mainWindow, miniAudicle 
     ui->tableWidget->setColumnWidth(2, 48);
     ui->tableWidget->setColumnWidth(3, 24);
     
-    ui->tableWidget->horizontalHeader()->setResizeMode(1, QHeaderView::Stretch);
+    ui->tableWidget->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
 }
 
 mAVMMonitor::~mAVMMonitor()


### PR DESCRIPTION
Qt 4 has been unsupported and unmaintained for years, and isn't packaged for many Linux distros any more. Luckily porting QT4 to QT5 is generally not too hard, and fairly well documented. In this case, quite trivial.

This seems to be working nicely, though I've only tested on Linux.

Fixes https://github.com/ccrma/miniAudicle/issues/40 and https://github.com/ccrma/miniAudicle/issues/41.