### PR TITLE
Qt6 mac

### DIFF
--- a/src/miniAudicle.pro
+++ b/src/miniAudicle.pro
@@ -45,7 +45,7 @@ QMAKE_CFLAGS += $$CFLAGS
 QMAKE_LFLAGS +=
 
 # on macOS link with qscintilla2_qt6.framework
-LIBS -= qscintilla2_qt6
+LIBS -= -lqscintilla2_qt6
 
 # libraries and frameworks to link against
 # assumes qscintilla2_qt6.framework in $$[QT_INSTALL_LIBS]

--- a/src/miniAudicle.pro
+++ b/src/miniAudicle.pro
@@ -24,7 +24,7 @@ DEFINES += HAVE_CONFIG_H
 # (unix systems) where to put intermediate objects files
 unix:OBJECTS_DIR = .
 # additional libraries to link
-LIBS += qscintilla2_qt6
+LIBS += -lqscintilla2_qt6
 
 
 #-------------------------------------------------

--- a/src/qt/mAMainWindow.cpp
+++ b/src/qt/mAMainWindow.cpp
@@ -39,6 +39,7 @@ U.S.A.
 #include "ZSettings.h"
 #include <QtGui/QCloseEvent>
 #include <QtWidgets/QPushButton>
+#include <QtCore/QRegularExpression>
 
 #include <list>
 
@@ -718,7 +719,9 @@ void mAMainWindow::setLogLevel()
     action->setChecked(true);
 
     ZSettings settings;
-    settings.set("/ChucK/LogLevel", ma->get_log_level());
+    settings.set("/ChucK/LogLevel", (long long)ma->get_log_level());
+    // 1.5.0.1 (ge) added (long long) to resolve error (macOS Qt6 build)
+    // conversion from 'long' to 'const QVariant' is ambiguous
 }
 
 

--- a/src/qt/madocumentview.cpp
+++ b/src/qt/madocumentview.cpp
@@ -283,7 +283,7 @@ void mADocumentView::exportAsWav()
             GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0); // generate Control+C event
 #else
             if(process.state() != QProcess::NotRunning)
-                kill(process.pid(), SIGINT);
+                kill(process.processId(), SIGINT);
 #endif
             process.waitForFinished(10);
         }


### PR DESCRIPTION
This builds miniAudicle using Qt6 on macOS; (this was done primarily for debugging in Qt Creator, which doesn't work currently in Windows, due to a DLL-related issue)

Dependency: will need qscintilla2_qt6 for mac; this zip file contains the framework with instructions on where to put the file; it also has the source to build the framework
[qscintilla_qt6.zip](https://github.com/ccrma/miniAudicle/files/11645334/qscintilla_qt6.zip)

FYI built and tested using Qt 6.5.0 on macOS Monterey

<img width="1077" alt="2023 06-mA-mac" src="https://github.com/ccrma/miniAudicle/assets/669967/c3b9b09c-e12b-4c4c-b67c-11d074594c82">
