### PR TITLE
preferences for audio driver selection in Qt

### DIFF
--- a/src/macosx/miniAudiclePreferencesController.mm
+++ b/src/macosx/miniAudiclePreferencesController.mm
@@ -745,7 +745,7 @@ miniAudicle_Version currentVersion()
 
 - (void)probeAudioInterfaces:(id)sender
 {
-    [mac miniAudicle]->probe();
+    [mac miniAudicle]->probe( NULL );
     
     const vector< RtAudio::DeviceInfo > & interfaces = [mac miniAudicle]->get_interfaces();
     vector< RtAudio::DeviceInfo >::size_type i, len = interfaces.size();

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -97,12 +97,12 @@ CHUCK_FULL_SRC_DIR=../../chuck/trunk/src
 CHUCK_MANUAL_DIR=$(CHUCK_FULL_SRC_DIR)/../doc/manual
 CHUCK_MANUAL=$(CHUCK_MANUAL_DIR)/ChucK_manual.pdf
 
-CHUCK_CSRCS= $(CHUCK_SRC_DIR)/core/util_math.cpp $(CHUCK_SRC_DIR)/core/util_network.c \
+CHUCK_CSRCS= $(CHUCK_SRC_DIR)/core/util_network.c \
     $(CHUCK_SRC_DIR)/core/util_raw.c $(CHUCK_SRC_DIR)/core/util_xforms.c \
     $(CHUCK_SRC_DIR)/$(SF_SRC) $(CHUCK_SRC_DIR)/core/chuck.tab.c \
     $(CHUCK_SRC_DIR)/core/chuck.yy.c
 
-CHUCK_CXXSRCS= $(CHUCK_SRC_DIR)/core/chuck.cpp \
+CHUCK_CXXSRCS= $(CHUCK_SRC_DIR)/core/chuck.cpp $(CHUCK_SRC_DIR)/core/util_math.cpp \
     $(CHUCK_SRC_DIR)/core/chuck_absyn.cpp $(CHUCK_SRC_DIR)/core/chuck_parse.cpp \
 	$(CHUCK_SRC_DIR)/core/chuck_errmsg.cpp $(CHUCK_SRC_DIR)/core/chuck_frame.cpp \
 	$(CHUCK_SRC_DIR)/core/chuck_symbol.cpp $(CHUCK_SRC_DIR)/core/chuck_table.cpp \

--- a/src/miniAudicle.cpp
+++ b/src/miniAudicle.cpp
@@ -174,7 +174,7 @@ miniAudicle::miniAudicle()
     // VM options (default)
     vm_options.enable_audio = TRUE;
     vm_options.enable_network = FALSE;
-    vm_options.driver = 0;
+    vm_options.driver = "";
     vm_options.dac = 0;
     vm_options.adc = 0;
     vm_options.srate = 0;
@@ -914,8 +914,7 @@ t_CKBOOL miniAudicle::start_vm()
         t_CKUINT srate = vm_options.srate != 0 ? vm_options.srate : SAMPLE_RATE_DEFAULT;
         t_CKUINT buffer_size = vm_options.buffer_size;
         t_CKUINT num_buffers = NUM_BUFFERS_DEFAULT;
-        t_CKUINT driver = vm_options.driver;
-        const char * driverName = ChuckAudio::driverApiToName(vm_options.driver);
+        const char * driverName = vm_options.driver.c_str();
         t_CKUINT dac = vm_options.dac;
         t_CKUINT adc = vm_options.adc;
         t_CKBOOL force_srate = vm_options.force_srate && vm_options.srate != 0;
@@ -1487,7 +1486,7 @@ t_CKBOOL miniAudicle::get_enable_network_thread()
 // name: set_driver()
 // desc: set audio driver by RtAudio::Api enum | 1.5.0.1 (ge) added
 //-----------------------------------------------------------------------------
-t_CKBOOL miniAudicle::set_driver( t_CKUINT driver )
+t_CKBOOL miniAudicle::set_driver( const char * driver )
 {
     vm_options.driver = driver;
     return TRUE;

--- a/src/miniAudicle.h
+++ b/src/miniAudicle.h
@@ -164,7 +164,7 @@ public:
     t_CKBOOL get_named_chugins( std::list< std::string > & chugins );
     t_CKBOOL add_query_func(t_CKBOOL (*func)(Chuck_Env *));
     // 1.5.0.1 (ge) added; takes an RtAudio::Api enum
-    t_CKBOOL set_driver(t_CKUINT driver);
+    t_CKBOOL set_driver(const char* driver);
 
     void set_ck_console_callback(void (*callback)(const char *));
 
@@ -211,7 +211,6 @@ protected:
 
     struct _vm_options
     {
-        t_CKUINT driver;
         t_CKUINT dac;
         t_CKUINT adc;
         t_CKUINT srate;
@@ -223,6 +222,7 @@ protected:
         t_CKBOOL enable_network;
         t_CKBOOL enable_block;
         t_CKBOOL force_srate;
+        std::string driver;
         std::list< std::string > library_paths;
         std::list< std::string > named_chugins;
         std::list< t_CKBOOL (*)(Chuck_Env *) > query_funcs;

--- a/src/miniAudicle.h
+++ b/src/miniAudicle.h
@@ -1,10 +1,10 @@
 /*----------------------------------------------------------------------------
-miniAudicle
-Cocoa GUI to chuck audio programming environment
+miniAudicle:
+  integrated developement environment for ChucK audio programming language
 
 Copyright (c) 2005-2013 Spencer Salazar.  All rights reserved.
-http://chuck.cs.princeton.edu/
-http://soundlab.cs.princeton.edu/
+  http://chuck.cs.princeton.edu/
+  http://soundlab.cs.princeton.edu/
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -23,19 +23,18 @@ U.S.A.
 -----------------------------------------------------------------------------*/
 
 //-----------------------------------------------------------------------------
-// file: miniaudicle.h
-// desc: ...
+// file: miniAudicle.h
+// desc: platform-independent miniAudicle interface
 //
 // author: Spencer Salazar (spencer@ccrma.stanford.edu)
 // date: Autumn 2005
 //-----------------------------------------------------------------------------
-
 #ifndef __MINIAUDICLE_H__
 #define __MINIAUDICLE_H__
 
 #include "chuck_compile.h"
-#include "util_thread.h"
 #include "chuck_type.h"
+#include "util_thread.h"
 #ifndef __CHIP_MODE__
 #include "RtAudio/RtAudio.h"
 #endif // __CHIP_MODE__
@@ -45,7 +44,7 @@ U.S.A.
 #include <vector>
 #include <queue>
 
-
+// forward reference
 class ChucK;
 
 
@@ -80,6 +79,11 @@ enum t_OTF_RESULT
     OTF_UNDEFINED
 };
 
+
+//-----------------------------------------------------------------------------
+// name: class miniAudicle
+// desc: primary interface to miniAudicle systems
+//-----------------------------------------------------------------------------
 class miniAudicle
 {
 public:
@@ -125,7 +129,9 @@ public:
     t_CKBOOL highlight_line( std::string & line,
                              miniAudicle_SyntaxHighlighting * sh );
 
-    t_CKBOOL probe();
+    // probe audio devices | 1.5.0.1 (ge) added driver argument
+    t_CKBOOL probe(const char* driver);
+
 #ifndef __CHIP_MODE__
     const std::vector< RtAudio::DeviceInfo > & get_interfaces();
 #endif // __CHIP_MODE__
@@ -157,7 +163,9 @@ public:
     t_CKBOOL set_named_chugins( std::list< std::string > & chugins );
     t_CKBOOL get_named_chugins( std::list< std::string > & chugins );
     t_CKBOOL add_query_func(t_CKBOOL (*func)(Chuck_Env *));
-    
+    // 1.5.0.1 (ge) added; takes an RtAudio::Api enum
+    t_CKBOOL set_driver(t_CKUINT driver);
+
     void set_ck_console_callback(void (*callback)(const char *));
 
 protected:
@@ -203,6 +211,7 @@ protected:
 
     struct _vm_options
     {
+        t_CKUINT driver;
         t_CKUINT dac;
         t_CKUINT adc;
         t_CKUINT srate;
@@ -221,9 +230,9 @@ protected:
 };
 
 
+// quickly determine if the two vectors are equal
 inline int compare_shred_vectors( const std::vector< Chuck_VM_Shred_Status * > & a,
                                   const std::vector< Chuck_VM_Shred_Status * > & b )
-/* quickly determine if the two vectors are equal */
 {
     std::vector< Chuck_VM_Shred_Status * >::size_type i,
     lenA = a.size(), lenB = b.size();
@@ -254,5 +263,3 @@ inline int compare_shred_vectors( const std::vector< Chuck_VM_Shred_Status * > &
 
 
 #endif // __MINIAUDICLE__H__
-
-

--- a/src/miniAudicle.pro
+++ b/src/miniAudicle.pro
@@ -1,7 +1,10 @@
 #-------------------------------------------------
-#
 # Project created by QtCreator 2011-11-21T18:38:04
-#
+#-------------------------------------------------
+# miniAudicle:
+# IDE for ChucK audio programming language
+#-------------------------------------------------
+
 #-------------------------------------------------
 # some useful references | 1.5.0.1 added
 # https://doc.qt.io/qt-6/qmake-environment-reference.html
@@ -103,7 +106,7 @@ win32 {
 DEFINES -= UNICODE
 # 2022 QTSIN
 DEFINES -= _UNICODE
-CFLAGS = -D__PLATFORM_WIN32__ -D__WINDOWS_MODERN__ -D__CHUCK_NO_MAIN__ -D__WINDOWS_DS__ -D_WINSOCKAPI_ -I../src -I../src/chuck/src/core -I../src/chuck/src/host -DWIN32 -D_WINDOWS -D__CK_MATH_DEFINE_ROUND_TRUNC__
+CFLAGS = -D__PLATFORM_WIN32__ -D__WINDOWS_MODERN__ -D__CHUCK_NO_MAIN__ -D__WINDOWS_DS__ -D__WINDOWS_WASAPI__ -D_WINSOCKAPI_ -I../src -I../src/chuck/src/core -I../src/chuck/src/host -DWIN32 -D_WINDOWS -D__CK_MATH_DEFINE_ROUND_TRUNC__
 QMAKE_CXXFLAGS += $$CFLAGS
 QMAKE_CFLAGS += $$CFLAGS
 QMAKE_LFLAGS += /libpath:../src/qt/lib ws2_32.lib dinput8.lib advapi32.lib kernel32.lib user32.lib gdi32.lib dsound.lib dxguid.lib winmm.lib ole32.lib

--- a/src/miniAudicle.pro
+++ b/src/miniAudicle.pro
@@ -106,7 +106,7 @@ win32 {
 DEFINES -= UNICODE
 # 2022 QTSIN
 DEFINES -= _UNICODE
-CFLAGS = -D__PLATFORM_WIN32__ -D__WINDOWS_MODERN__ -D__CHUCK_NO_MAIN__ -D__WINDOWS_DS__ -D__WINDOWS_WASAPI__ -D_WINSOCKAPI_ -I../src -I../src/chuck/src/core -I../src/chuck/src/host -DWIN32 -D_WINDOWS -D__CK_MATH_DEFINE_ROUND_TRUNC__
+CFLAGS = -D__PLATFORM_WIN32__ -D__WINDOWS_MODERN__ -D__CHUCK_NO_MAIN__ -D__WINDOWS_DS__ -D__WINDOWS_WASAPI__ -D__WINDOWS_ASIO__ -D_WINSOCKAPI_ -I../src -I../src/chuck/src/core -I../src/chuck/src/host -I../src/chuck/src/host/RtAudio/include -DWIN32 -D_WINDOWS -D__CK_MATH_DEFINE_ROUND_TRUNC__
 QMAKE_CXXFLAGS += $$CFLAGS
 QMAKE_CFLAGS += $$CFLAGS
 QMAKE_LFLAGS += /libpath:../src/qt/lib ws2_32.lib dinput8.lib advapi32.lib kernel32.lib user32.lib gdi32.lib dsound.lib dxguid.lib winmm.lib ole32.lib
@@ -127,6 +127,10 @@ RC_FILE = qt/icon/miniAudicle.rc
 # source files to compile
 #-------------------------------------------------
 SOURCES += \
+    chuck/src/host/RtAudio/include/asio.cpp \
+    chuck/src/host/RtAudio/include/asiodrivers.cpp \
+    chuck/src/host/RtAudio/include/asiolist.cpp \
+    chuck/src/host/RtAudio/include/iasiothiscallresolver.cpp \
     qt/mAMainWindow.cpp \
     qt/main.cpp \
     chuck/src/host/chuck_audio.cpp \
@@ -222,6 +226,17 @@ win32 {
 #-------------------------------------------------
 HEADERS  += qt/mAMainWindow.h \
     chuck/src/core/ulib_doc.h \
+    chuck/src/host/RtAudio/include/asio.h \
+    chuck/src/host/RtAudio/include/asiodrivers.h \
+    chuck/src/host/RtAudio/include/asiodrvr.h \
+    chuck/src/host/RtAudio/include/asiolist.h \
+    chuck/src/host/RtAudio/include/asiosys.h \
+    chuck/src/host/RtAudio/include/dsound.h \
+    chuck/src/host/RtAudio/include/functiondiscoverykeys_devpkey.h \
+    chuck/src/host/RtAudio/include/ginclude.h \
+    chuck/src/host/RtAudio/include/iasiodrv.h \
+    chuck/src/host/RtAudio/include/iasiothiscallresolver.h \
+    chuck/src/host/RtAudio/include/soundcard.h \
     chuck/src/host/chuck_audio.h \
     chuck/src/host/chuck_console.h \
     chuck/src/host/RtAudio/RtAudio.h \
@@ -374,3 +389,6 @@ OTHER_FILES += \
     qt/icon/removelast.png \
     qt/icon/removeall.png \
     qt/icon/miniAudicle.rc
+
+DISTFILES += \
+    chuck/src/host/RtAudio/include/asioinfo.txt

--- a/src/qt/ZSettings.cpp
+++ b/src/qt/ZSettings.cpp
@@ -1,10 +1,10 @@
 /*----------------------------------------------------------------------------
-miniAudicle
-GUI to ChucK audio programming environment
+miniAudicle:
+  integrated developement environment for ChucK audio programming language
 
 Copyright (c) 2005-2013 Spencer Salazar.  All rights reserved.
-http://chuck.cs.princeton.edu/
-http://soundlab.cs.princeton.edu/
+  http://chuck.cs.princeton.edu/
+  http://soundlab.cs.princeton.edu/
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -22,34 +22,58 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
 U.S.A.
 -----------------------------------------------------------------------------*/
 
+//-----------------------------------------------------------------------------
+// file: ZSettings.cpp
+// desc: setting utility
+//
+// author: Spencer Salazar (spencer@ccrma.stanford.edu)
+//-----------------------------------------------------------------------------
 #include "ZSettings.h"
 
-
+// static instantiation
 QMap<QString, QVariant> ZSettings::s_defaults;
 
 
-ZSettings::ZSettings(QObject *parent) :
-    QSettings(parent)
-{
-}
+//-----------------------------------------------------------------------------
+// name: ZSettings()
+// desc: constructor
+//-----------------------------------------------------------------------------
+ZSettings::ZSettings( QObject * parent )
+    : QSettings( parent )
+{ }
 
-void ZSettings::setDefault(const QString &key, const QVariant &value)
+
+//-----------------------------------------------------------------------------
+// name: setDefault()
+// desc: set default
+//-----------------------------------------------------------------------------
+void ZSettings::setDefault( const QString & key, const QVariant & value )
 {
+    // set default
     s_defaults[key] = value;
 }
 
-QVariant ZSettings::get(const QString &key, const QVariant &fallback)
+
+//-----------------------------------------------------------------------------
+// name: get()
+// desc: get value by key
+//-----------------------------------------------------------------------------
+QVariant ZSettings::get( const QString & key, const QVariant & fallback )
 {
     QSettings settings;
-    if(settings.contains(key))
+    // check settings
+    if( settings.contains(key) )
         return settings.value(key);
+    // if not found, check defaults
     if(s_defaults.contains(key))
         return s_defaults[key];
+    // nothing found
     return fallback;
 }
 
-void ZSettings::set(const QString &key, const QVariant &value)
+void ZSettings::set( const QString & key, const QVariant & value )
 {
     QSettings settings;
-    settings.setValue(key, value);
+    // set the value
+    settings.setValue( key, value );
 }

--- a/src/qt/ZSettings.h
+++ b/src/qt/ZSettings.h
@@ -1,10 +1,10 @@
 /*----------------------------------------------------------------------------
-miniAudicle
-GUI to ChucK audio programming environment
+miniAudicle:
+  integrated developement environment for ChucK audio programming language
 
 Copyright (c) 2005-2013 Spencer Salazar.  All rights reserved.
-http://chuck.cs.princeton.edu/
-http://soundlab.cs.princeton.edu/
+  http://chuck.cs.princeton.edu/
+  http://soundlab.cs.princeton.edu/
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -22,24 +22,44 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
 U.S.A.
 -----------------------------------------------------------------------------*/
 
+//-----------------------------------------------------------------------------
+// file: ZSettings.h
+// desc: setting utility
+//
+// author: Spencer Salazar (spencer@ccrma.stanford.edu)
+//-----------------------------------------------------------------------------
 #ifndef ZSETTINGS_H
 #define ZSETTINGS_H
 
 #include <QSettings>
 
+
+//-----------------------------------------------------------------------------
+// name: class ZSetting
+// desc: settings class
+//-----------------------------------------------------------------------------
 class ZSettings : public QSettings
 {
     Q_OBJECT
+
 public:
-    explicit ZSettings(QObject *parent = 0);
-    
-    static void setDefault(const QString &key, const QVariant &value);
-    
-    void set(const QString &key, const QVariant &value);
-    QVariant get(const QString &key, const QVariant &fallback = QVariant());
-    
+    // constructor
+    explicit ZSettings( QObject * parent = 0 );
+
+public:
+    // set value
+    void set( const QString & key, const QVariant & value );
+    // get a value by key
+    QVariant get( const QString & key, const QVariant & fallback = QVariant() );
+
+public:
+    // set defeault
+    static void setDefault( const QString & key, const QVariant & value );
+
 private:
+    // the default map
     static QMap<QString, QVariant> s_defaults;
 };
+
 
 #endif // ZSETTINGS_H

--- a/src/qt/ZSettings.h
+++ b/src/qt/ZSettings.h
@@ -53,7 +53,7 @@ public:
     QVariant get( const QString & key, const QVariant & fallback = QVariant() );
 
 public:
-    // set defeault
+    // set default
     static void setDefault( const QString & key, const QVariant & value );
 
 private:

--- a/src/qt/mAMainWindow.cpp
+++ b/src/qt/mAMainWindow.cpp
@@ -33,6 +33,7 @@ U.S.A.
 #include "mASocketManager.h"
 
 #include "chuck.h"
+#include "chuck_audio.h"
 
 #include <QtWidgets/QMessageBox>
 #include <QtGui/QGuiApplication>
@@ -625,7 +626,7 @@ void mAMainWindow::toggleVM()
         ma->set_enable_network_thread(settings.get(mAPreferencesEnableNetwork).toBool());
         ma->set_adc(settings.get(mAPreferencesAudioInput).toInt());
         ma->set_dac(settings.get(mAPreferencesAudioOutput).toInt());
-        ma->set_driver(settings.get(mAPreferencesAudioDriver).toInt());
+        ma->set_driver(ChuckAudio::driverApiToName(settings.get(mAPreferencesAudioDriver).toInt()));
         ma->set_num_inputs(settings.get(mAPreferencesInputChannels).toInt());
         ma->set_num_outputs(settings.get(mAPreferencesOutputChannels).toInt());
         ma->set_sample_rate(settings.get(mAPreferencesSampleRate).toInt());

--- a/src/qt/mAMainWindow.cpp
+++ b/src/qt/mAMainWindow.cpp
@@ -1,10 +1,10 @@
 /*----------------------------------------------------------------------------
-miniAudicle
-GUI to ChucK audio programming environment
+miniAudicle:
+  integrated developement environment for ChucK audio programming language
 
 Copyright (c) 2005-2013 Spencer Salazar.  All rights reserved.
-http://chuck.cs.princeton.edu/
-http://soundlab.cs.princeton.edu/
+  http://chuck.cs.princeton.edu/
+  http://soundlab.cs.princeton.edu/
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -625,6 +625,7 @@ void mAMainWindow::toggleVM()
         ma->set_enable_network_thread(settings.get(mAPreferencesEnableNetwork).toBool());
         ma->set_adc(settings.get(mAPreferencesAudioInput).toInt());
         ma->set_dac(settings.get(mAPreferencesAudioOutput).toInt());
+        ma->set_driver(settings.get(mAPreferencesAudioDriver).toInt());
         ma->set_num_inputs(settings.get(mAPreferencesInputChannels).toInt());
         ma->set_num_outputs(settings.get(mAPreferencesOutputChannels).toInt());
         ma->set_sample_rate(settings.get(mAPreferencesSampleRate).toInt());

--- a/src/qt/mAMainWindow.h
+++ b/src/qt/mAMainWindow.h
@@ -1,10 +1,10 @@
 /*----------------------------------------------------------------------------
-miniAudicle
-GUI to ChucK audio programming environment
+miniAudicle:
+  integrated developement environment for ChucK audio programming language
 
 Copyright (c) 2005-2013 Spencer Salazar.  All rights reserved.
-http://chuck.cs.princeton.edu/
-http://soundlab.cs.princeton.edu/
+  http://chuck.cs.princeton.edu/
+  http://soundlab.cs.princeton.edu/
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/qt/mAPreferencesWindow.h
+++ b/src/qt/mAPreferencesWindow.h
@@ -1,10 +1,10 @@
 /*----------------------------------------------------------------------------
-miniAudicle
-GUI to ChucK audio programming environment
+miniAudicle:
+  integrated developement environment for ChucK audio programming language
 
 Copyright (c) 2005-2013 Spencer Salazar.  All rights reserved.
-http://chuck.cs.princeton.edu/
-http://soundlab.cs.princeton.edu/
+  http://chuck.cs.princeton.edu/
+  http://soundlab.cs.princeton.edu/
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -22,6 +22,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
 U.S.A.
 -----------------------------------------------------------------------------*/
 
+//-----------------------------------------------------------------------------
+// file: mAPreferencesWindow.h
+// desc: header for miniAudicle preferences
+//
+// author: Spencer Salazar (spencer@ccrma.stanford.edu)
+// date: 2005-present
+//-----------------------------------------------------------------------------
 #ifndef MAPREFERENCESWINDOW_H
 #define MAPREFERENCESWINDOW_H
 
@@ -33,27 +40,38 @@ namespace Ui {
 class mAPreferencesWindow;
 }
 
+
+// forward reference
 class miniAudicle;
 
+
+//-----------------------------------------------------------------------------
+// name: class mAPreferencesWindow
+// desc: contoller for the preferences dialog window
+//-----------------------------------------------------------------------------
 class mAPreferencesWindow : public QDialog
 {
     Q_OBJECT
     
 public:
-    explicit mAPreferencesWindow(QWidget *parent, miniAudicle * ma);
+    // constructor
+    explicit mAPreferencesWindow( QWidget * parent, miniAudicle * ma );
+    // destructor
     ~mAPreferencesWindow();
-    
+
+public:
+    // configure default settings
     static void configureDefaults();
     
-public slots:
-    
+public slots: // slots
     void ok();
     void cancel();
     void restoreDefaults();
     
-    void ProbeAudioDevices();    
-    void SelectedAudioOutputChanged();
-    void SelectedAudioInputChanged();
+    void probeAudioDevices( int driver );
+    void selectedAudioDriverChanged();
+    void selectedAudioOutputChanged();
+    void selectedAudioInputChanged();
     
     void syntaxColoringTypeChanged();
     void syntaxColoringChangeColor();
@@ -64,7 +82,7 @@ public slots:
     
     void changeCurrentDirectory();
     
-signals:
+signals: // signals
     void preferencesChanged();
     
 private:
@@ -127,6 +145,7 @@ extern const QString mAPreferencesOutputChannels;
 extern const QString mAPreferencesInputChannels;
 extern const QString mAPreferencesSampleRate;
 extern const QString mAPreferencesBufferSize;
+extern const QString mAPreferencesAudioDriver;
 extern const QString mAPreferencesVMStallTimeout;
 
 extern const QString mAPreferencesEnableNetwork;

--- a/src/qt/mAPreferencesWindow.h
+++ b/src/qt/mAPreferencesWindow.h
@@ -68,7 +68,7 @@ public slots: // slots
     void cancel();
     void restoreDefaults();
     
-    void probeAudioDevices( int driver );
+    void probeAudioDevices( int driver, bool resetToDefault = false );
     void selectedAudioDriverChanged();
     void selectedAudioOutputChanged();
     void selectedAudioInputChanged();

--- a/src/qt/mAPreferencesWindow.ui
+++ b/src/qt/mAPreferencesWindow.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>435</width>
+    <width>445</width>
     <height>367</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>435</width>
+    <width>445</width>
     <height>367</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>435</width>
+    <width>445</width>
     <height>367</height>
    </size>
   </property>
@@ -35,11 +35,11 @@
    <iconset resource="miniAudicle.qrc">
     <normaloff>:/icon/miniAudicle.png</normaloff>:/icon/miniAudicle.png</iconset>
   </property>
+  <property name="sizeGripEnabled">
+   <bool>false</bool>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
-    <number>5</number>
-   </property>
-   <property name="margin">
     <number>5</number>
    </property>
    <item>
@@ -47,17 +47,20 @@
      <property name="minimumSize">
       <size>
        <width>425</width>
-       <height>325</height>
+       <height>305</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
        <width>425</width>
-       <height>325</height>
+       <height>305</height>
       </size>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
+     </property>
+     <property name="documentMode">
+      <bool>true</bool>
      </property>
      <widget class="QWidget" name="audioTab">
       <attribute name="title">
@@ -104,9 +107,55 @@
          <item>
           <widget class="QCheckBox" name="enableAudio">
            <property name="text">
-            <string>Enable Audio</string>
+            <string>Enable audio</string>
            </property>
           </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_11">
+         <item>
+          <widget class="QLabel" name="label_11">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Audio driver:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="audioDriver">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>135</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_10">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
@@ -571,7 +620,6 @@
            </property>
            <property name="font">
             <font>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>
@@ -590,7 +638,6 @@
            </property>
            <property name="font">
             <font>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>
@@ -756,14 +803,94 @@
  </resources>
  <connections>
   <connection>
-   <sender>okButton</sender>
+   <sender>syntaxColoringChangeButton</sender>
    <signal>clicked()</signal>
    <receiver>mAPreferencesWindow</receiver>
-   <slot>ok()</slot>
+   <slot>syntaxColoringChangeColor()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>456</x>
-     <y>390</y>
+     <x>386</x>
+     <y>131</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>220</x>
+     <y>204</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>syntaxColoringType</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>mAPreferencesWindow</receiver>
+   <slot>syntaxColoringTypeChanged()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>152</x>
+     <y>130</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>220</x>
+     <y>204</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>addChuginButton</sender>
+   <signal>clicked()</signal>
+   <receiver>mAPreferencesWindow</receiver>
+   <slot>addChugin()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>69</x>
+     <y>298</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>220</x>
+     <y>204</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>removeChuginButton</sender>
+   <signal>clicked()</signal>
+   <receiver>mAPreferencesWindow</receiver>
+   <slot>removeChugin()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>44</x>
+     <y>298</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>220</x>
+     <y>204</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>currentDirectoryButton</sender>
+   <signal>clicked()</signal>
+   <receiver>mAPreferencesWindow</receiver>
+   <slot>changeCurrentDirectory()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>423</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>200</x>
+     <y>181</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>restoreDefaultsButton</sender>
+   <signal>clicked()</signal>
+   <receiver>mAPreferencesWindow</receiver>
+   <slot>restoreDefaults()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>348</y>
     </hint>
     <hint type="destinationlabel">
      <x>260</x>
@@ -779,7 +906,7 @@
    <hints>
     <hint type="sourcelabel">
      <x>326</x>
-     <y>390</y>
+     <y>348</y>
     </hint>
     <hint type="destinationlabel">
      <x>260</x>
@@ -788,14 +915,14 @@
    </hints>
   </connection>
   <connection>
-   <sender>restoreDefaultsButton</sender>
+   <sender>okButton</sender>
    <signal>clicked()</signal>
    <receiver>mAPreferencesWindow</receiver>
-   <slot>restoreDefaults()</slot>
+   <slot>ok()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>80</x>
-     <y>390</y>
+     <x>436</x>
+     <y>348</y>
     </hint>
     <hint type="destinationlabel">
      <x>260</x>
@@ -804,18 +931,18 @@
    </hints>
   </connection>
   <connection>
-   <sender>audioInput</sender>
+   <sender>audioDriver</sender>
    <signal>currentIndexChanged(int)</signal>
    <receiver>mAPreferencesWindow</receiver>
-   <slot>SelectedAudioInputChanged()</slot>
+   <slot>selectedAudioDriverChanged()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>258</x>
-     <y>132</y>
+     <x>155</x>
+     <y>86</y>
     </hint>
     <hint type="destinationlabel">
-     <x>220</x>
-     <y>204</y>
+     <x>222</x>
+     <y>183</y>
     </hint>
    </hints>
   </connection>
@@ -823,95 +950,31 @@
    <sender>audioOutput</sender>
    <signal>currentIndexChanged(int)</signal>
    <receiver>mAPreferencesWindow</receiver>
-   <slot>SelectedAudioOutputChanged()</slot>
+   <slot>selectedAudioOutputChanged()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>258</x>
-     <y>103</y>
+     <x>256</x>
+     <y>123</y>
     </hint>
     <hint type="destinationlabel">
-     <x>220</x>
-     <y>204</y>
+     <x>222</x>
+     <y>183</y>
     </hint>
    </hints>
   </connection>
   <connection>
-   <sender>syntaxColoringChangeButton</sender>
-   <signal>clicked()</signal>
-   <receiver>mAPreferencesWindow</receiver>
-   <slot>syntaxColoringChangeColor()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>149</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>220</x>
-     <y>204</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>syntaxColoringType</sender>
+   <sender>audioInput</sender>
    <signal>currentIndexChanged(int)</signal>
    <receiver>mAPreferencesWindow</receiver>
-   <slot>syntaxColoringTypeChanged()</slot>
+   <slot>selectedAudioInputChanged()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>118</x>
-     <y>148</y>
+     <x>251</x>
+     <y>160</y>
     </hint>
     <hint type="destinationlabel">
-     <x>220</x>
-     <y>204</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>addChuginButton</sender>
-   <signal>clicked()</signal>
-   <receiver>mAPreferencesWindow</receiver>
-   <slot>addChugin()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>38</x>
-     <y>347</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>220</x>
-     <y>204</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>removeChuginButton</sender>
-   <signal>clicked()</signal>
-   <receiver>mAPreferencesWindow</receiver>
-   <slot>removeChugin()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>66</x>
-     <y>347</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>220</x>
-     <y>204</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>currentDirectoryButton</sender>
-   <signal>clicked()</signal>
-   <receiver>mAPreferencesWindow</receiver>
-   <slot>changeCurrentDirectory()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>328</x>
-     <y>63</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>200</x>
-     <y>181</y>
+     <x>222</x>
+     <y>183</y>
     </hint>
    </hints>
   </connection>
@@ -920,8 +983,9 @@
   <slot>ok()</slot>
   <slot>cancel()</slot>
   <slot>restoreDefaults()</slot>
-  <slot>SelectedAudioOutputChanged()</slot>
-  <slot>SelectedAudioInputChanged()</slot>
+  <slot>selectedAudioDriverChanged()</slot>
+  <slot>selectedAudioOutputChanged()</slot>
+  <slot>selectedAudioInputChanged()</slot>
   <slot>syntaxColoringTypeChanged()</slot>
   <slot>syntaxColoringChangeColor()</slot>
   <slot>addChugin()</slot>

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -44,7 +44,7 @@ using namespace std;
 int main(int argc, char *argv[])
 {
     // set style, e.g., Windows, windowsvista, Fusion, macos
-    QApplication::setStyle("Fusion");
+    QApplication::setStyle( "windowsvista" );
 
     // get and print available styles
     // QStringList styles = QStyleFactory::keys();

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -31,6 +31,7 @@ U.S.A.
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QStyleFactory>
 #include <iostream>
+#include <string>
 using namespace std;
 
 #include "mAMainWindow.h"
@@ -43,8 +44,10 @@ using namespace std;
 //-----------------------------------------------------------------------------
 int main(int argc, char *argv[])
 {
+    // style
+    string styleName = "Fusion";
     // set style, e.g., Windows, windowsvista, Fusion, macos
-    QApplication::setStyle( "windowsvista" );
+    QApplication::setStyle( styleName.c_str() );
 
     // get and print available styles
     // QStringList styles = QStyleFactory::keys();

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -21,34 +21,56 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
 U.S.A.
 -----------------------------------------------------------------------------*/
-
+//-----------------------------------------------------------------------------
+// name: main.cpp
+// desc: entry point file for Qt version of miniAudicle
+//
+// author: Spencer Salazar
+// date: 2005-present
+//-----------------------------------------------------------------------------
 #include <QtWidgets/QApplication>
+#include <QtWidgets/QStyleFactory>
+#include <iostream>
+using namespace std;
 
 #include "mAMainWindow.h"
 #include "mASocketManager.h"
 
+
+//-----------------------------------------------------------------------------
+// name: main()
+// desc: the entry point
+//-----------------------------------------------------------------------------
 int main(int argc, char *argv[])
-{    
-    QApplication a(argc, argv);
-    a.setStyle("windowsvista");
-    
-//    for(int i = 0; i < a.arguments().length(); i++)
-//    {
-//        fprintf(stderr, "arg: %s\n", a.arguments()[i].toUtf8().constData());
-//        fflush(stderr);
-//    }
-    
-    if(a.arguments().length() >= 2 && QFileInfo(a.arguments()[1]).exists())
+{
+    // set style, e.g., Windows, windowsvista, Fusion, macos
+    QApplication::setStyle("Fusion");
+
+    // get and print available styles
+    // QStringList styles = QStyleFactory::keys();
+    // for(QStringList::Iterator s = styles.begin(); s != styles.end(); s++ )
+    //     qDebug( "[miniAudicle]: QStyle available: %s", qUtf8Printable(*s) );
+
+    // Qt application initialization
+    QApplication app(argc, argv);
+
+    // argument to open file on remote
+    if( app.arguments().length() >= 2 && QFileInfo(app.arguments()[1]).exists() )
     {
-        fprintf(stderr, "[miniAudicle]: attempting to open file '%s' on remote\n", 
-                a.arguments()[1].toUtf8().constData());
-        fflush(stderr);
-        if(mASocketManager::openFileOnRemote(a.arguments()[1]))
+        // print
+        cerr << "[miniAudicle]: attempting to open file '"
+             << app.arguments()[1].toUtf8().constData()
+             << "' on remote..." << endl;
+        // open on remote
+        if( mASocketManager::openFileOnRemote(app.arguments()[1]) )
             return 0;
     }
-    
+
+    // declare main miniAudicle window
     mAMainWindow w;
+    // show
     w.show();
 
-    return a.exec();
+    // enter Qt run loop
+    return app.exec();
 }


### PR DESCRIPTION
![Screenshot (4)](https://github.com/ccrma/miniAudicle/assets/669967/5073f2e1-1a87-43d1-ae6d-e02393f3c373)

part of the 1.5.0.1 patch
Qt version only and thus primarily affects Windows and Linux
preferences dialog window now has an Audio driver drop-down combo box, populated with available drivers (determined at compile time, with preprocessor: DirectSound, WASAPI, ALSA, Pulse, Jack, CoreAudio
selecting a driver triggers a new probe of available audio I/O devices (which is potentially different depending on the driver) and the Audio output and Audio input drop-down combo boxes are re-populated
settings load and save drivers; default driver is inherited from ChuckAudio