### PR TITLE
mac preferences update: audio driver + probe chugins

### DIFF
--- a/src/macosx/Resources/English.lproj/miniAudicle.xib
+++ b/src/macosx/Resources/English.lproj/miniAudicle.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment version="1090" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -675,7 +675,7 @@ CA
                     </menu>
                 </menuItem>
             </items>
-            <point key="canvasLocation" x="139" y="154"/>
+            <point key="canvasLocation" x="142" y="174"/>
         </menu>
         <menu title="View" id="1173">
             <items>
@@ -939,26 +939,26 @@ CA
         <window title="Console Monitor" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="404" userLabel="Console Monitor">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="528" y="100" width="447" height="320"/>
+            <rect key="contentRect" x="995" y="113" width="512" height="360"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <value key="minSize" type="size" width="213" height="107"/>
             <view key="contentView" id="405">
-                <rect key="frame" x="0.0" y="0.0" width="447" height="320"/>
+                <rect key="frame" x="0.0" y="0.0" width="512" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView fixedFrame="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1007">
-                        <rect key="frame" x="0.0" y="0.0" width="447" height="320"/>
+                        <rect key="frame" x="0.0" y="0.0" width="512" height="360"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" drawsBackground="NO" id="BdI-v0-Am4">
-                            <rect key="frame" x="0.0" y="0.0" width="432" height="320"/>
+                            <rect key="frame" x="0.0" y="0.0" width="497" height="360"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" findStyle="panel" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="1008">
-                                    <rect key="frame" x="0.0" y="0.0" width="417" height="320"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="482" height="360"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <size key="minSize" width="432" height="320"/>
+                                    <size key="minSize" width="497" height="360"/>
                                     <size key="maxSize" width="879" height="10000000"/>
                                     <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <connections>
@@ -973,7 +973,7 @@ CA
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="1366">
-                            <rect key="frame" x="432" y="0.0" width="15" height="320"/>
+                            <rect key="frame" x="497" y="0.0" width="15" height="360"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <connections>
@@ -1021,7 +1021,7 @@ CA
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                    <size key="minSize" width="435" height="350"/>
+                                    <size key="minSize" width="420" height="350"/>
                                     <size key="maxSize" width="885" height="10000000"/>
                                     <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                 </textView>
@@ -1094,7 +1094,7 @@ http://chuck.cs.princeton.edu/</string>
             <value key="minSize" type="size" width="213" height="107"/>
             <view key="contentView" id="532">
                 <rect key="frame" x="0.0" y="0.0" width="450" height="426"/>
-                <autoresizingMask key="autoresizingMask"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <tabView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="597">
                         <rect key="frame" x="13" y="44" width="424" height="375"/>
@@ -1487,7 +1487,7 @@ Changes will not take effect until miniAudicle is restarted.
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1386">
-                                            <rect key="frame" x="18" y="293" width="121" height="18"/>
+                                            <rect key="frame" x="18" y="293" width="122" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Enable ChuGins" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="1387">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1499,7 +1499,7 @@ Changes will not take effect until miniAudicle is restarted.
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" id="5U8-i5-o23">
                                                 <rect key="frame" x="1" y="1" width="368" height="239"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" autosaveColumns="NO" headerView="1401" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="1412" id="1400">
                                                         <rect key="frame" x="0.0" y="0.0" width="368" height="222"/>
@@ -1572,6 +1572,17 @@ Changes will not take effect until miniAudicle is restarted.
                                             <connections>
                                                 <action selector="deleteChuginPath:" target="626" id="1418"/>
                                             </connections>
+                                        </button>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AcR-tY-KGh">
+                                            <rect key="frame" x="271" y="10" width="125" height="32"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="push" title="Probe ChuGins" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="als-4z-pHN">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <action selector="probeChugins:" target="626" id="qWV-9V-Y1k"/>
+                                                </connections>
+                                            </buttonCell>
                                         </button>
                                     </subviews>
                                 </view>
@@ -1935,6 +1946,7 @@ DQ
                 <outlet property="output_channels" destination="786" id="815"/>
                 <outlet property="preferences_tab_view" destination="597" id="1289"/>
                 <outlet property="preferences_window" destination="531" id="646"/>
+                <outlet property="probe_chugins" destination="AcR-tY-KGh" id="HxA-ex-K3u"/>
                 <outlet property="sample_rate" destination="790" id="816"/>
                 <outlet property="soundfiles_directory" destination="688" id="691"/>
                 <outlet property="syntax_color" destination="699" id="702"/>
@@ -2143,7 +2155,7 @@ DQ
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="gJ8-GE-1nV">
                             <rect key="frame" x="1" y="1" width="582" height="427"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" headerView="1382" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="1118" id="1117">
                                     <rect key="frame" x="0.0" y="0.0" width="582" height="410"/>
@@ -2274,9 +2286,9 @@ DQ
         </numberFormatter>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="18" height="17"/>
+        <image name="NSAddTemplate" width="14" height="13"/>
         <image name="NSApplicationIcon" width="32" height="32"/>
-        <image name="NSRemoveTemplate" width="18" height="5"/>
+        <image name="NSRemoveTemplate" width="14" height="4"/>
         <image name="chugin" width="512" height="512"/>
     </resources>
 </document>

--- a/src/macosx/Resources/English.lproj/miniAudicle.xib
+++ b/src/macosx/Resources/English.lproj/miniAudicle.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <deployment version="1080" identifier="macosx"/>
+        <deployment version="1090" identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -755,7 +755,7 @@ CA
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="Pzf-RP-xP2">
                             <rect key="frame" x="1" y="1" width="253" height="236"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="sequential" autosaveColumns="NO" rowHeight="15" headerView="1365" id="285">
                                     <rect key="frame" x="0.0" y="0.0" width="253" height="219"/>
@@ -841,7 +841,7 @@ CA
                         </tableHeaderView>
                     </scrollView>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="291">
-                        <rect key="frame" x="17" y="338" width="188" height="14"/>
+                        <rect key="frame" x="18" y="338" width="188" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" controlSize="small" selectable="YES" sendsActionOnEndEditing="YES" title="running time:" id="1294">
                             <font key="font" metaFont="message" size="11"/>
@@ -849,19 +849,8 @@ CA
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="293">
-                        <rect key="frame" x="17" y="316" width="46" height="14"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" controlSize="small" selectable="YES" sendsActionOnEndEditing="YES" id="1295">
-                            <font key="font" metaFont="message" size="11"/>
-                            <string key="title">shreds:
-</string>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="881">
-                        <rect key="frame" x="98" y="338" width="107" height="14"/>
+                        <rect key="frame" x="92" y="338" width="113" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="1296">
                             <font key="font" metaFont="message" size="11"/>
@@ -870,7 +859,7 @@ CA
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="884">
-                        <rect key="frame" x="65" y="316" width="140" height="14"/>
+                        <rect key="frame" x="62" y="316" width="140" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" controlSize="small" selectable="YES" sendsActionOnEndEditing="YES" id="1297">
                             <font key="font" metaFont="message" size="11"/>
@@ -879,7 +868,7 @@ CA
                         </textFieldCell>
                     </textField>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1277">
-                        <rect key="frame" x="210" y="333" width="76" height="19"/>
+                        <rect key="frame" x="210" y="336" width="76" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="square" title="Remove Last" bezelStyle="shadowlessSquare" alignment="center" borderStyle="border" inset="2" id="1298">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -890,7 +879,7 @@ CA
                         </connections>
                     </button>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1278">
-                        <rect key="frame" x="210" y="304" width="76" height="19"/>
+                        <rect key="frame" x="210" y="306" width="76" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="square" title="Clear VM" bezelStyle="shadowlessSquare" alignment="center" borderStyle="border" inset="2" id="1299">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -900,6 +889,17 @@ CA
                             <action selector="clearVM:" target="331" id="mQG-hC-7ig"/>
                         </connections>
                     </button>
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="293">
+                        <rect key="frame" x="18" y="316" width="46" height="14"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" controlSize="small" selectable="YES" sendsActionOnEndEditing="YES" id="1295">
+                            <font key="font" metaFont="message" size="11"/>
+                            <string key="title">shreds:
+</string>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
                 </subviews>
             </view>
             <connections>
@@ -951,7 +951,7 @@ CA
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" drawsBackground="NO" id="BdI-v0-Am4">
                             <rect key="frame" x="0.0" y="0.0" width="432" height="320"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" findStyle="panel" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="1008">
                                     <rect key="frame" x="0.0" y="0.0" width="417" height="320"/>
@@ -1014,7 +1014,7 @@ CA
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" drawsBackground="NO" id="gbL-lz-swd">
                             <rect key="frame" x="0.0" y="0.0" width="435" height="350"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textView editable="NO" importsGraphics="NO" verticallyResizable="YES" usesFontPanel="YES" findStyle="panel" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="435" customClass="miniAudicleShellTextView">
                                     <rect key="frame" x="0.0" y="0.0" width="420" height="350"/>
@@ -1106,17 +1106,6 @@ http://chuck.cs.princeton.edu/</string>
                                     <rect key="frame" x="10" y="33" width="404" height="329"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="602">
-                                            <rect key="frame" x="214" y="195" width="101" height="18"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="1316">
-                                                <font key="font" metaFont="system"/>
-                                                <string key="title">Input channels:
-</string>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="604">
                                             <rect key="frame" x="18" y="292" width="103" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
@@ -1125,17 +1114,6 @@ http://chuck.cs.princeton.edu/</string>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
                                         </button>
-                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="605">
-                                            <rect key="frame" x="17" y="195" width="113" height="18"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="1318">
-                                                <font key="font" metaFont="system"/>
-                                                <string key="title">Output channels:
-</string>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="608">
                                             <rect key="frame" x="169" y="292" width="217" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
@@ -1153,147 +1131,6 @@ http://chuck.cs.princeton.edu/</string>
   
 Changes will not take effect until miniAudicle is restarted.
 </string>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="756">
-                                            <rect key="frame" x="17" y="225" width="95" height="18"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Audio input:" id="1321">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="757">
-                                            <rect key="frame" x="114" y="220" width="273" height="26"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <popUpButtonCell key="cell" type="push" title="Built-in Audio" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="760" id="1322">
-                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="menu"/>
-                                                <menu key="menu" title="OtherViews" id="758">
-                                                    <items>
-                                                        <menuItem title="Built-in Audio" state="on" id="760"/>
-                                                    </items>
-                                                </menu>
-                                            </popUpButtonCell>
-                                            <connections>
-                                                <action selector="selectedAudioInputChanged:" target="626" id="818"/>
-                                            </connections>
-                                        </popUpButton>
-                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="762">
-                                            <rect key="frame" x="17" y="255" width="95" height="18"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Audio output:" id="1323">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="763">
-                                            <rect key="frame" x="114" y="250" width="273" height="26"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <popUpButtonCell key="cell" type="push" title="Built-in Audio" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="765" id="1324">
-                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="menu"/>
-                                                <menu key="menu" title="OtherViews" id="764">
-                                                    <items>
-                                                        <menuItem title="Built-in Audio" state="on" id="765"/>
-                                                    </items>
-                                                </menu>
-                                            </popUpButtonCell>
-                                            <connections>
-                                                <action selector="selectedAudioOutputChanged:" target="626" id="819"/>
-                                            </connections>
-                                        </popUpButton>
-                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="781">
-                                            <rect key="frame" x="317" y="190" width="70" height="26"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <popUpButtonCell key="cell" type="push" title="2" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="785" id="1325">
-                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="menu"/>
-                                                <menu key="menu" title="OtherViews" id="782">
-                                                    <items>
-                                                        <menuItem title="1" id="784"/>
-                                                        <menuItem title="2" state="on" id="785"/>
-                                                    </items>
-                                                </menu>
-                                            </popUpButtonCell>
-                                        </popUpButton>
-                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="786">
-                                            <rect key="frame" x="132" y="190" width="70" height="26"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <popUpButtonCell key="cell" type="push" title="2" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="789" id="1326">
-                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="menu"/>
-                                                <menu key="menu" title="OtherViews" id="787">
-                                                    <items>
-                                                        <menuItem title="1" id="788"/>
-                                                        <menuItem title="2" state="on" id="789"/>
-                                                    </items>
-                                                </menu>
-                                            </popUpButtonCell>
-                                        </popUpButton>
-                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="790">
-                                            <rect key="frame" x="106" y="160" width="103" height="26"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <popUpButtonCell key="cell" type="push" title="44100" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="793" id="1327">
-                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="menu"/>
-                                                <menu key="menu" title="OtherViews" id="791">
-                                                    <items>
-                                                        <menuItem title="32000" id="794"/>
-                                                        <menuItem title="44100" state="on" id="793"/>
-                                                    </items>
-                                                </menu>
-                                            </popUpButtonCell>
-                                        </popUpButton>
-                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="795">
-                                            <rect key="frame" x="17" y="165" width="87" height="18"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Sample rate:" id="1328">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="805">
-                                            <rect key="frame" x="111" y="105" width="183" height="32"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <buttonCell key="cell" type="push" title="Probe Audio Interfaces" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="1329">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="probeAudioInterfaces:" target="626" id="809"/>
-                                            </connections>
-                                        </button>
-                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="890">
-                                            <rect key="frame" x="296" y="160" width="91" height="26"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <popUpButtonCell key="cell" type="push" title="256" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="256" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="898" id="1330">
-                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="menu"/>
-                                                <menu key="menu" title="OtherViews" id="891">
-                                                    <items>
-                                                        <menuItem title="16" tag="16" id="895"/>
-                                                        <menuItem title="32" tag="32" id="899"/>
-                                                        <menuItem title="64" tag="64" id="896"/>
-                                                        <menuItem title="128" tag="128" id="897"/>
-                                                        <menuItem title="256" state="on" tag="256" id="898"/>
-                                                        <menuItem title="512" tag="512" id="893"/>
-                                                        <menuItem title="1024" tag="1024" id="892"/>
-                                                        <menuItem title="2048" tag="2048" id="900"/>
-                                                    </items>
-                                                </menu>
-                                            </popUpButtonCell>
-                                        </popUpButton>
-                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="894">
-                                            <rect key="frame" x="219" y="165" width="75" height="18"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Buffer size:" id="1331">
-                                                <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
@@ -1334,13 +1171,201 @@ Changes will not take effect until miniAudicle is restarted.
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="602">
+                                            <rect key="frame" x="215" y="167" width="101" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="1316">
+                                                <font key="font" metaFont="system"/>
+                                                <string key="title">Input channels:
+</string>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="605">
+                                            <rect key="frame" x="18" y="167" width="113" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="1318">
+                                                <font key="font" metaFont="system"/>
+                                                <string key="title">Output channels:
+</string>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="756">
+                                            <rect key="frame" x="18" y="197" width="95" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Audio input:" id="1321">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="757">
+                                            <rect key="frame" x="115" y="192" width="273" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="Built-in Audio" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="760" id="1322">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" title="OtherViews" id="758">
+                                                    <items>
+                                                        <menuItem title="Built-in Audio" state="on" id="760"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <action selector="selectedAudioInputChanged:" target="626" id="818"/>
+                                            </connections>
+                                        </popUpButton>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="762">
+                                            <rect key="frame" x="18" y="227" width="95" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Audio output:" id="1323">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bud-0D-WU1">
+                                            <rect key="frame" x="18" y="257" width="95" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Audio driver:" id="GLb-Ma-INy">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="763">
+                                            <rect key="frame" x="115" y="222" width="273" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="Built-in Audio" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="765" id="1324">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" title="OtherViews" id="764">
+                                                    <items>
+                                                        <menuItem title="Built-in Audio" state="on" id="765"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <action selector="selectedAudioOutputChanged:" target="626" id="819"/>
+                                            </connections>
+                                        </popUpButton>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MNX-iU-yb2">
+                                            <rect key="frame" x="115" y="252" width="141" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="CoreAudio" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="ECb-ne-xBP" id="MhB-G9-2rW">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" title="OtherViews" id="4jG-dE-xZW">
+                                                    <items>
+                                                        <menuItem title="CoreAudio" state="on" id="ECb-ne-xBP"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <action selector="selectedAudioDriverChanged:" target="626" id="311-GG-CSM"/>
+                                            </connections>
+                                        </popUpButton>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="781">
+                                            <rect key="frame" x="318" y="162" width="70" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="2" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="785" id="1325">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" title="OtherViews" id="782">
+                                                    <items>
+                                                        <menuItem title="1" id="784"/>
+                                                        <menuItem title="2" state="on" id="785"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                        </popUpButton>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="786">
+                                            <rect key="frame" x="133" y="162" width="70" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="2" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="789" id="1326">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" title="OtherViews" id="787">
+                                                    <items>
+                                                        <menuItem title="1" id="788"/>
+                                                        <menuItem title="2" state="on" id="789"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                        </popUpButton>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="790">
+                                            <rect key="frame" x="107" y="132" width="103" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="44100" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="793" id="1327">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" title="OtherViews" id="791">
+                                                    <items>
+                                                        <menuItem title="32000" id="794"/>
+                                                        <menuItem title="44100" state="on" id="793"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                        </popUpButton>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="795">
+                                            <rect key="frame" x="18" y="137" width="87" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Sample rate:" id="1328">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="890">
+                                            <rect key="frame" x="297" y="132" width="91" height="26"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="256" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="256" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="898" id="1330">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" title="OtherViews" id="891">
+                                                    <items>
+                                                        <menuItem title="16" tag="16" id="895"/>
+                                                        <menuItem title="32" tag="32" id="899"/>
+                                                        <menuItem title="64" tag="64" id="896"/>
+                                                        <menuItem title="128" tag="128" id="897"/>
+                                                        <menuItem title="256" state="on" tag="256" id="898"/>
+                                                        <menuItem title="512" tag="512" id="893"/>
+                                                        <menuItem title="1024" tag="1024" id="892"/>
+                                                        <menuItem title="2048" tag="2048" id="900"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                        </popUpButton>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="894">
+                                            <rect key="frame" x="220" y="137" width="75" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Buffer size:" id="1331">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="805">
+                                            <rect key="frame" x="111" y="84" width="183" height="32"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="push" title="Probe Audio Interfaces" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="1329">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="probeAudioInterfaces:" target="626" id="809"/>
+                                            </connections>
+                                        </button>
                                     </subviews>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Editing" identifier="2" id="598">
                                 <view key="view" id="599">
                                     <rect key="frame" x="10" y="33" width="404" height="329"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="615">
                                             <rect key="frame" x="17" y="293" width="84" height="15"/>
@@ -1459,7 +1484,7 @@ Changes will not take effect until miniAudicle is restarted.
                             <tabViewItem label="ChuGins" identifier="" id="1384">
                                 <view key="view" id="1385">
                                     <rect key="frame" x="10" y="33" width="404" height="329"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1386">
                                             <rect key="frame" x="18" y="293" width="121" height="18"/>
@@ -1472,11 +1497,11 @@ Changes will not take effect until miniAudicle is restarted.
                                         <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1397">
                                             <rect key="frame" x="17" y="46" width="370" height="241"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <clipView key="contentView" ambiguous="YES" id="5U8-i5-o23">
+                                            <clipView key="contentView" id="5U8-i5-o23">
                                                 <rect key="frame" x="1" y="1" width="368" height="239"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <subviews>
-                                                    <outlineView verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" autosaveColumns="NO" headerView="1401" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="1412" id="1400">
+                                                    <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" autosaveColumns="NO" headerView="1401" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="1412" id="1400">
                                                         <rect key="frame" x="0.0" y="0.0" width="368" height="222"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
@@ -1554,7 +1579,7 @@ Changes will not take effect until miniAudicle is restarted.
                             <tabViewItem label="Miscellaneous" identifier="" id="613">
                                 <view key="view" id="614">
                                     <rect key="frame" x="10" y="33" width="404" height="329"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button hidden="YES" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="618">
                                             <rect key="frame" x="244" y="60" width="142" height="18"/>
@@ -1871,6 +1896,7 @@ DQ
                     </connections>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="132" y="-74"/>
         </menu>
         <menu title="Menu" id="557" userLabel="Shred Table Menu">
             <items>
@@ -1885,11 +1911,13 @@ DQ
                     </connections>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="135" y="129"/>
         </menu>
         <customObject id="626" userLabel="miniAudiclePreferencesController" customClass="miniAudiclePreferencesController">
             <connections>
                 <outlet property="accept_network_commands" destination="608" id="629"/>
                 <outlet property="audio_changes_warning" destination="662" id="817"/>
+                <outlet property="audio_driver" destination="MNX-iU-yb2" id="J7K-dk-qnk"/>
                 <outlet property="audio_input" destination="757" id="813"/>
                 <outlet property="audio_output" destination="763" id="812"/>
                 <outlet property="auto_open_console_monitor" destination="780" id="811"/>
@@ -1924,6 +1952,7 @@ DQ
                     </connections>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="-715" y="-860"/>
         </menu>
         <window title="Add Multiple Shreds" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="901" userLabel="Add Shreds">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
@@ -2073,7 +2102,7 @@ DQ
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" autoresizesSubviews="NO" id="URm-cK-4sr">
                             <rect key="frame" x="0.0" y="0.0" width="432" height="320"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1006" customClass="mAConsoleMonitorView">
                                     <rect key="frame" x="0.0" y="0.0" width="1" height="1"/>
@@ -2114,7 +2143,7 @@ DQ
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="gJ8-GE-1nV">
                             <rect key="frame" x="1" y="1" width="582" height="427"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" headerView="1382" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="1118" id="1117">
                                     <rect key="frame" x="0.0" y="0.0" width="582" height="410"/>
@@ -2202,6 +2231,7 @@ DQ
             <connections>
                 <outlet property="delegate" destination="1129" id="1131"/>
             </connections>
+            <point key="canvasLocation" x="-515" y="251"/>
         </window>
         <customObject id="1129" userLabel="mABrowserController" customClass="mABrowserController">
             <connections>
@@ -2226,6 +2256,7 @@ DQ
                     </openGLView>
                 </subviews>
             </view>
+            <point key="canvasLocation" x="-459" y="-343"/>
         </window>
         <numberFormatter formatterBehavior="10_0" positiveFormat="#,##0.0##" negativeFormat="-#,##0.0##" thousandSeparator="," id="1216" userLabel="FloatFormatter">
             <attributedString key="attributedStringForZero">

--- a/src/macosx/miniAudicleController.h
+++ b/src/macosx/miniAudicleController.h
@@ -125,6 +125,9 @@ extern NSString * const mAVirtualMachineDidTurnOffNotification;
 - (NSPoint)lastWindowTopLeftCorner;
 - (void)setLastWindowTopLeftCorner:(NSPoint)p;
 
+// windowing helpers
+- (void)activateConsoleMonitor:(id)sender;
+
 // UI callbacks
 - (IBAction)openDocumentInTab:(id)sender;
 - (IBAction)newWindow:(id)sender;

--- a/src/macosx/miniAudicleController.mm
+++ b/src/macosx/miniAudicleController.mm
@@ -185,7 +185,12 @@ NSString * const mAChuginExtension = @"chug";
     
     // init preferences
     // [mapc initDefaults];
-//    [self newDocument:self];
+    // [self newDocument:self];
+
+    // activate and raise
+    // [console_monitor activateMonitor];
+    // [vm_monitor activateMonitor:self];
+    // [[NSApplication sharedApplication] arrangeInFront:self];
 }
 
 //-----------------------------------------------------------------------------
@@ -419,6 +424,13 @@ NSString * const mAChuginExtension = @"chug";
 - (void)setLastWindowTopLeftCorner:(NSPoint)p
 {
     last_window_tlc = p;
+}
+
+// activate console monitor | 1.5.0.4 (ge) this seems sus?
+- (void)activateConsoleMonitor:(id)sender
+{
+    // make appear and give focus
+    [console_monitor activateMonitor];
 }
 
 - (void)windowDidBecomeKey:(NSNotification *)n
@@ -1275,8 +1287,3 @@ const static size_t num_default_tile_dimensions = sizeof( default_tile_dimension
 
 
 @end
-
-
-
-
-

--- a/src/macosx/miniAudiclePreferencesController.h
+++ b/src/macosx/miniAudiclePreferencesController.h
@@ -124,6 +124,7 @@ extern NSString * mAPreferencesChangedNotification;
     NSText * keybindings_field_editor;
     NSArray * keybindings;
     
+    IBOutlet NSButton * probe_chugins;
     IBOutlet NSButton * enable_chugins;
     NSMutableArray * chugin_paths;
 }
@@ -148,6 +149,7 @@ extern NSString * mAPreferencesChangedNotification;
 
 - (IBAction)addChuginPath:(id)sender;
 - (IBAction)deleteChuginPath:(id)sender;
+- (IBAction)probeChugins:(id)sender;
 
 @end
 

--- a/src/macosx/miniAudiclePreferencesController.h
+++ b/src/macosx/miniAudiclePreferencesController.h
@@ -40,6 +40,7 @@ extern NSString * mAPreferencesEnableAudio;
 extern NSString * mAPreferencesEnableCallback;
 extern NSString * mAPreferencesEnableBlocking;
 extern NSString * mAPreferencesEnableStdSystem;
+extern NSString * mAPreferencesAudioDriver;
 extern NSString * mAPreferencesAudioOutput;
 extern NSString * mAPreferencesAudioInput;
 extern NSString * mAPreferencesInputChannels; /* -1 indicates highest possible */
@@ -96,6 +97,7 @@ extern NSString * mAPreferencesChangedNotification;
     
     id enable_audio;
     id accept_network_commands;
+    id audio_driver;
     id audio_output;
     id audio_input;
     id output_channels;
@@ -128,6 +130,7 @@ extern NSString * mAPreferencesChangedNotification;
 
 - (void)awakeFromNib;
 - (void)initDefaults;
+- (void)rebuildAudioDriverGUI;
 - (void)cancel:(id)sender;
 - (void)confirm:(id)sender;
 - (void)restoreDefaults:(id)sender;
@@ -139,6 +142,7 @@ extern NSString * mAPreferencesChangedNotification;
 - (void)syntaxColorChanged:(id)sender;
 - (void)enableSyntaxHighlightingChanged:(id)sender;
 - (void)probeAudioInterfaces:(id)sender;
+- (void)selectedAudioDriverChanged:(id)sender;
 - (void)selectedAudioOutputChanged:(id)sender;
 - (void)selectedAudioInputChanged:(id)sender;
 


### PR DESCRIPTION
bringing miniAudicle (mac, Cocoa) to parity with miniAudicle (Qt); for now the mac Audio driver dropdown is only "CoreAudio" but has been verified with additional (Dummy) driver; tried to follow code convention for both features, but probably did some sus things, hence this PR...

<img width="450" alt="ma-mac-driver" src="https://github.com/ccrma/miniAudicle/assets/669967/00ca390b-1578-4663-b39f-89a1951fb31c">
<img width="1052" alt="ma-mac-probe-chug" src="https://github.com/ccrma/miniAudicle/assets/669967/3ace9087-82d1-4276-b00c-e7d39c23e6ea">
