### PR TITLE
Add Format Code function + Format on Save (Qt frontend only)

### DIFF
--- a/src/qt/mAMainWindow.cpp
+++ b/src/qt/mAMainWindow.cpp
@@ -335,6 +335,8 @@ void mAMainWindow::newFile()
     documentView->setTabWidget(ui->tabWidget);
     QObject::connect(m_preferencesWindow, SIGNAL(preferencesChanged()),
                      documentView, SLOT(preferencesChanged()));
+    QObject::connect(documentView, SIGNAL(formatError(QString)),
+                     statusBar(), SLOT(showMessage(QString)));
 
     ui->tabWidget->addTab(documentView, QIcon(), "untitled");
     ui->tabWidget->setCurrentIndex(ui->tabWidget->count()-1);
@@ -383,6 +385,8 @@ void mAMainWindow::openFile(const QString &path)
 
             QObject::connect(m_preferencesWindow, SIGNAL(preferencesChanged()),
                              documentView, SLOT(preferencesChanged()));
+            QObject::connect(documentView, SIGNAL(formatError(QString)),
+                             statusBar(), SLOT(showMessage(QString)));
 
             ui->tabWidget->addTab(documentView, QIcon(), fileInfo.fileName());
             ui->tabWidget->setCurrentIndex(ui->tabWidget->count()-1);
@@ -434,6 +438,8 @@ void mAMainWindow::openExample()
             documentView->setTabWidget(ui->tabWidget);
             QObject::connect(m_preferencesWindow, SIGNAL(preferencesChanged()),
                              documentView, SLOT(preferencesChanged()));
+            QObject::connect(documentView, SIGNAL(formatError(QString)),
+                             statusBar(), SLOT(showMessage(QString)));
             documentView->setReadOnly(true);
 
             ui->tabWidget->addTab(documentView, QIcon(), fileInfo.fileName());
@@ -550,6 +556,7 @@ void mAMainWindow::tabSelected(int index)
     ui->actionPaste->disconnect();
     ui->actionSelect_All->disconnect();
     ui->actionExport_as_WAV->disconnect();
+    ui->actionFormat_Code->disconnect();
 
     if(currentView == NULL)
     {
@@ -570,6 +577,7 @@ void mAMainWindow::tabSelected(int index)
     connect(ui->actionPaste, SIGNAL(triggered()), currentView, SIGNAL(paste()));
     connect(ui->actionSelect_All, SIGNAL(triggered()), currentView, SIGNAL(selectAll()));
     connect(ui->actionExport_as_WAV, SIGNAL(triggered()), currentView, SLOT(exportAsWav()));
+    connect(ui->actionFormat_Code, SIGNAL(triggered()), currentView, SLOT(formatCode()));
 }
 
 #pragma mark

--- a/src/qt/mAMainWindow.ui
+++ b/src/qt/mAMainWindow.ui
@@ -83,6 +83,8 @@
     <addaction name="separator"/>
     <addaction name="actionSelect_All"/>
     <addaction name="separator"/>
+    <addaction name="actionFormat_Code"/>
+    <addaction name="separator"/>
     <addaction name="actionPreferences"/>
    </widget>
    <widget class="QMenu" name="menuChucK">
@@ -278,6 +280,14 @@
    </property>
    <property name="shortcut">
     <string>Alt+,</string>
+   </property>
+  </action>
+  <action name="actionFormat_Code">
+   <property name="text">
+    <string>Format Code</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+I</string>
    </property>
   </action>
   <action name="actionAdd_Shred">

--- a/src/qt/mAPreferencesWindow.cpp
+++ b/src/qt/mAPreferencesWindow.cpp
@@ -84,6 +84,7 @@ const QString mAPreferencesUseTabs = "/GUI/Editing/UsesTabs";
 const QString mAPreferencesTabSize = "/GUI/Editing/TabSize";
 const QString mAPreferencesShowLineNumbers = "/GUI/Editing/ShowLineNumbers";
 const QString mAPreferencesWindowingStyle = "/GUI/Editing/WindowingStyle"; // 1.5.0.4 (ge) added
+const QString mAPreferencesFormatterCommand = "/GUI/Editing/FormatterCommand";
 
 const QString mAPreferencesCurrentDirectory = "/Miscellaneous/CurrentDirectory";
 
@@ -190,6 +191,7 @@ void mAPreferencesWindow::configureDefaults()
 
     ZSettings::setDefault(mAPreferencesUseTabs, false);
     ZSettings::setDefault(mAPreferencesTabSize, 4);
+    ZSettings::setDefault(mAPreferencesFormatterCommand, "chuckfmt");
     // ZSettings::setDefault(mAPreferences)
 
     ZSettings::setDefault(mAPreferencesEnableChuGins, true);
@@ -279,6 +281,7 @@ void mAPreferencesWindow::loadSettingsToGUI()
    
     ui->editorUsesTabs->setChecked(settings.get(mAPreferencesUseTabs).toBool());
     ui->tabWidth->setValue(settings.get(mAPreferencesTabSize).toInt());
+    ui->formatterCommand->setText(settings.get(mAPreferencesFormatterCommand).toString());
     
     ui->enableChugins->setChecked(settings.get(mAPreferencesEnableChuGins).toBool());
     ui->chuginsList->clear();
@@ -366,6 +369,7 @@ void mAPreferencesWindow::loadGUIToSettings()
     
     settings.set(mAPreferencesUseTabs, ui->editorUsesTabs->isChecked());
     settings.set(mAPreferencesTabSize, ui->tabWidth->value());
+    settings.set(mAPreferencesFormatterCommand, ui->formatterCommand->text());
 
     settings.set(mAPreferencesEnableChuGins, ui->enableChugins->isChecked());
     QStringList paths;

--- a/src/qt/mAPreferencesWindow.cpp
+++ b/src/qt/mAPreferencesWindow.cpp
@@ -85,6 +85,7 @@ const QString mAPreferencesTabSize = "/GUI/Editing/TabSize";
 const QString mAPreferencesShowLineNumbers = "/GUI/Editing/ShowLineNumbers";
 const QString mAPreferencesWindowingStyle = "/GUI/Editing/WindowingStyle"; // 1.5.0.4 (ge) added
 const QString mAPreferencesFormatterCommand = "/GUI/Editing/FormatterCommand";
+const QString mAPreferencesFormatOnSave = "/GUI/Editing/FormatOnSave";
 
 const QString mAPreferencesCurrentDirectory = "/Miscellaneous/CurrentDirectory";
 
@@ -192,6 +193,7 @@ void mAPreferencesWindow::configureDefaults()
     ZSettings::setDefault(mAPreferencesUseTabs, false);
     ZSettings::setDefault(mAPreferencesTabSize, 4);
     ZSettings::setDefault(mAPreferencesFormatterCommand, "chuckfmt");
+    ZSettings::setDefault(mAPreferencesFormatOnSave, false);
     // ZSettings::setDefault(mAPreferences)
 
     ZSettings::setDefault(mAPreferencesEnableChuGins, true);
@@ -282,6 +284,7 @@ void mAPreferencesWindow::loadSettingsToGUI()
     ui->editorUsesTabs->setChecked(settings.get(mAPreferencesUseTabs).toBool());
     ui->tabWidth->setValue(settings.get(mAPreferencesTabSize).toInt());
     ui->formatterCommand->setText(settings.get(mAPreferencesFormatterCommand).toString());
+    ui->formatOnSave->setChecked(settings.get(mAPreferencesFormatOnSave).toBool());
     
     ui->enableChugins->setChecked(settings.get(mAPreferencesEnableChuGins).toBool());
     ui->chuginsList->clear();
@@ -370,6 +373,7 @@ void mAPreferencesWindow::loadGUIToSettings()
     settings.set(mAPreferencesUseTabs, ui->editorUsesTabs->isChecked());
     settings.set(mAPreferencesTabSize, ui->tabWidth->value());
     settings.set(mAPreferencesFormatterCommand, ui->formatterCommand->text());
+    settings.set(mAPreferencesFormatOnSave, ui->formatOnSave->isChecked());
 
     settings.set(mAPreferencesEnableChuGins, ui->enableChugins->isChecked());
     QStringList paths;

--- a/src/qt/mAPreferencesWindow.h
+++ b/src/qt/mAPreferencesWindow.h
@@ -141,6 +141,7 @@ extern const QString mAPreferencesUseTabs;
 extern const QString mAPreferencesTabSize;
 extern const QString mAPreferencesShowLineNumbers;
 extern const QString mAPreferencesWindowingStyle;
+extern const QString mAPreferencesFormatterCommand;
 
 extern const QString mAPreferencesCurrentDirectory;
 

--- a/src/qt/mAPreferencesWindow.h
+++ b/src/qt/mAPreferencesWindow.h
@@ -142,6 +142,7 @@ extern const QString mAPreferencesTabSize;
 extern const QString mAPreferencesShowLineNumbers;
 extern const QString mAPreferencesWindowingStyle;
 extern const QString mAPreferencesFormatterCommand;
+extern const QString mAPreferencesFormatOnSave;
 
 extern const QString mAPreferencesCurrentDirectory;
 

--- a/src/qt/mAPreferencesWindow.ui
+++ b/src/qt/mAPreferencesWindow.ui
@@ -628,6 +628,13 @@
         </layout>
        </item>
        <item>
+        <widget class="QCheckBox" name="formatOnSave">
+         <property name="text">
+          <string>Format on save</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/mAPreferencesWindow.ui
+++ b/src/qt/mAPreferencesWindow.ui
@@ -614,6 +614,20 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_formatter">
+         <item>
+          <widget class="QLabel" name="label_formatter">
+           <property name="text">
+            <string>Formatter command:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="formatterCommand"/>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/madocumentview.cpp
+++ b/src/qt/madocumentview.cpp
@@ -394,6 +394,12 @@ void mADocumentView::save()
 
     if(file != NULL)
     {
+        // format-on-save: formatCode() is idempotent (no-op on already-formatted
+        // or on formatter error) so we can unconditionally call it when enabled
+        ZSettings settings;
+        if(settings.get(mAPreferencesFormatOnSave).toBool())
+            formatCode();
+
         file->open(QIODevice::WriteOnly | QIODevice::Truncate);
         ui->textEdit->write(file);
         file->flush();
@@ -439,6 +445,11 @@ void mADocumentView::saveAs()
 
     if(file != NULL)
     {
+        // format-on-save: see save() for rationale
+        ZSettings settings;
+        if(settings.get(mAPreferencesFormatOnSave).toBool())
+            formatCode();
+
         file->open(QIODevice::WriteOnly | QIODevice::Truncate);
         ui->textEdit->write(file);
         file->flush();

--- a/src/qt/madocumentview.cpp
+++ b/src/qt/madocumentview.cpp
@@ -590,3 +590,78 @@ void mADocumentView::remove()
     }    
 }
 
+
+void mADocumentView::formatCode()
+{
+    QString input = ui->textEdit->text();
+    if(input.isEmpty()) return;
+
+    int line = 0, col = 0;
+    ui->textEdit->getCursorPosition(&line, &col);
+    int firstVisible = ui->textEdit->firstVisibleLine();
+
+    ZSettings settings;
+    QString command = settings.get(mAPreferencesFormatterCommand, "chuckfmt").toString().trimmed();
+    if(command.isEmpty())
+    {
+        emit formatError("formatter command is empty (set it in Preferences)");
+        return;
+    }
+
+    QString bin = which(command);
+    if(bin.isEmpty())
+    {
+        emit formatError(QString("formatter not found: %1").arg(command));
+        return;
+    }
+
+    // contract is stdin->stdout with no args, so any formatter works; do not
+    // pass the file path. do NOT set MergedChannels either -- stderr must stay
+    // separate so error text never contaminates the replacement buffer
+    QProcess process;
+    process.start(bin, QStringList());
+    if(!process.waitForStarted(3000))
+    {
+        emit formatError(QString("failed to start %1").arg(command));
+        return;
+    }
+    process.write(input.toUtf8());
+    process.closeWriteChannel();
+
+    // soft upper bound; chuckfmt typically returns in <100ms
+    if(!process.waitForFinished(10000))
+    {
+        process.kill();
+        emit formatError("formatter timed out");
+        return;
+    }
+
+    if(process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0)
+    {
+        QByteArray err = process.readAllStandardError();
+        QString msg = QString::fromUtf8(err).trimmed();
+        if(msg.isEmpty()) msg = QString("%1 exited with code %2").arg(command).arg(process.exitCode());
+        emit formatError(QString("formatter failed: %1").arg(msg));
+        return;
+    }
+
+    QByteArray out = process.readAllStandardOutput();
+    QString formatted = QString::fromUtf8(out);
+
+    // skip the buffer replace when nothing changed so the modified flag
+    // doesn't get flipped on an already-formatted document
+    if(formatted == input) return;
+
+    // selectAll+replaceSelectedText (not setText) preserves undo history,
+    // and the begin/endUndoAction wrap makes one Ctrl+Z revert the whole format
+    ui->textEdit->beginUndoAction();
+    ui->textEdit->selectAll(true);
+    ui->textEdit->replaceSelectedText(formatted);
+    ui->textEdit->endUndoAction();
+
+    int newLineCount = ui->textEdit->lines();
+    int restoredLine = qMin(line, newLineCount - 1);
+    ui->textEdit->setCursorPosition(restoredLine, col);
+    ui->textEdit->setFirstVisibleLine(qMin(firstVisible, newLineCount - 1));
+}
+

--- a/src/qt/madocumentview.cpp
+++ b/src/qt/madocumentview.cpp
@@ -622,7 +622,10 @@ void mADocumentView::formatCode()
     QString bin = which(command);
     if(bin.isEmpty())
     {
-        emit formatError(QString("formatter not found: %1").arg(command));
+        if(command == "chuckfmt")
+            emit formatError("chuckfmt not found in PATH -- install from https://github.com/aik2mlj/chuckfmt");
+        else
+            emit formatError(QString("formatter not found: %1").arg(command));
         return;
     }
 

--- a/src/qt/madocumentview.h
+++ b/src/qt/madocumentview.h
@@ -78,6 +78,7 @@ public slots:
     void readOnlySaveDialogClicked(QAbstractButton *button);    
     void preferencesChanged();
     void exportAsWav();
+    void formatCode();
     
 signals:
     void undo();
@@ -86,6 +87,7 @@ signals:
     void copy();
     void paste();
     void selectAll();
+    void formatError(const QString &message);
 
 protected:
     void showEvent( QShowEvent * event );


### PR DESCRIPTION
Hi Ge, this PR is to integrate (and shamelessly promote) my [chuckfmt](https://github.com/aik2mlj/chuckfmt) util into miniAudicle.

This adds an **Edit → Format Code** menu item (`Ctrl+Shift+I`, which Qt auto-maps to `Cmd+Shift+I` on macOS) that pipes the active document through an external formatter via stdin → stdout and replaces the buffer with the result. The formatter command is configurable under **Preferences → Editing** and defaults to `chuckfmt`; any tool that honors the stdin → stdout contract will work. There's also an opt-in **Format on Save** checkbox (off by default) that runs the formatter before each save and save-as. If the user doesn't have `chuckfmt`, they will not run into issues unless they manually trigger formatting or turn on format-on-save.

The format itself is a single action that can be reverted by `Ctrl+Z`. If the formatter isn't on PATH, exits non-zero, or exceeds a 10-second timeout, the buffer is left untouched and the reason is shown on the status bar. Format-on-save follows the same rule: if formatting fails, the save still proceeds with the unformatted content.

This is the Qt frontend only, which covers the Linux and Windows builds plus `make mac-qt` for macOS. It does **not** cover the default Cocoa frontend for macOS yet. I'll implement it once I borrow a mac.

## Testing

Install [chuckfmt](https://github.com/aik2mlj/chuckfmt) according to its document.

- [x] Format Code reformats a messy `.ck`; one `Ctrl+Z` reverts the entire change
- [x] Change formmatter to a nonexisting binary → status bar shows `formatter not found: X`, buffer unchanged
- [x] Formatter exits non-zero → status bar shows `formatter failed: …`
- [x] Formatter hangs → `formatter timed out` after ~10s
- [x] Two open tabs: trigger an error in each; no duplicated status messages
- [x] Enable **Format on Save**, save a messy file → written file is formatted; disable → plain save
- [x] **Format on Save** with a broken formatter still writes the file
- [x] Open an example (read-only), Ctrl+S then offers Save As, which writes the formatted content
